### PR TITLE
fix/1 refreshToken 암호화 저장

### DIFF
--- a/src/main/java/com/example/qoocca_be/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/qoocca_be/global/jwt/JwtTokenProvider.java
@@ -46,7 +46,7 @@ public class JwtTokenProvider {
 
         cookieUtils.addRefreshTokenCookie(res, refreshToken);
 
-        return new LoginResponseDto(accessToken, null);
+        return new LoginResponseDto(accessToken, refreshToken);
     }
 
     public String generateAccessToken(Long userId, String role){

--- a/src/main/java/com/example/qoocca_be/global/utils/CookieUtils.java
+++ b/src/main/java/com/example/qoocca_be/global/utils/CookieUtils.java
@@ -3,36 +3,82 @@ package com.example.qoocca_be.global.utils;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
 
 @Component
 public class CookieUtils {
-  public void addRefreshTokenCookie(HttpServletResponse res, String refreshToken) {
-    Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
-    refreshCookie.setHttpOnly(true);
-//    refreshCookie.setSecure(true); // HTTPS 통신 시 필수
-    refreshCookie.setPath("/");
-    refreshCookie.setMaxAge(7 * 24 * 60 * 60);
-    res.addCookie(refreshCookie);
-  }
 
-  public String getRefreshToken(HttpServletRequest req) {
-    if (req.getCookies() != null) {
-      for (Cookie cookie : req.getCookies()) {
-        if ("refreshToken".equals(cookie.getName())) {
-          return cookie.getValue();
+    @Value("${jwt.cookie-encryption-key:this-is-a-very-secret-key-32chars}")
+    private String encryptionKey;
+
+    private static final String ALGORITHM = "AES";
+
+    public void addRefreshTokenCookie(HttpServletResponse res, String refreshToken) {
+        if (refreshToken == null) return;
+
+        try {
+            String encryptedToken = encrypt(refreshToken);
+
+            ResponseCookie cookie = ResponseCookie.from("refreshToken", encryptedToken)
+                    .httpOnly(true)
+                    .secure(false) // 로컬 테스트 시 false
+                    .path("/")
+                    .maxAge(7 * 24 * 60 * 60)
+                    .sameSite("Lax")
+                    .build();
+
+            res.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        } catch (Exception e) {
+            throw new RuntimeException("쿠키 암호화 중 오류 발생", e);
         }
-      }
     }
-    return null;
-  }
 
-  public void deleteRefreshTokenCookie(HttpServletResponse res) {
-    Cookie refreshCookie = new Cookie("refreshToken", null);
-    refreshCookie.setHttpOnly(true);
-//    refreshCookie.setSecure(true); // HTTPS 통신 시 필수
-    refreshCookie.setMaxAge(0);
-    refreshCookie.setPath("/");
-    res.addCookie(refreshCookie);
-  }
+    public String getRefreshToken(HttpServletRequest req) {
+        if (req.getCookies() != null) {
+            for (Cookie cookie : req.getCookies()) {
+                if ("refreshToken".equals(cookie.getName())) {
+                    try {
+                        return decrypt(cookie.getValue());
+                    } catch (Exception e) {
+                        return null;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    // AES 암호화 로직
+    private String encrypt(String data) throws Exception {
+        SecretKeySpec keySpec = new SecretKeySpec(encryptionKey.getBytes(), ALGORITHM);
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec);
+        byte[] encrypted = cipher.doFinal(data.getBytes());
+        return Base64.getEncoder().encodeToString(encrypted);
+    }
+
+    // AES 복호화 로직
+    private String decrypt(String encryptedData) throws Exception {
+        SecretKeySpec keySpec = new SecretKeySpec(encryptionKey.getBytes(), ALGORITHM);
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.DECRYPT_MODE, keySpec);
+        byte[] decoded = Base64.getDecoder().decode(encryptedData);
+        return new String(cipher.doFinal(decoded));
+    }
+
+    public void deleteRefreshTokenCookie(HttpServletResponse res) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0)
+                .build();
+        res.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
 }

--- a/src/main/java/com/example/qoocca_be/user/service/AuthService.java
+++ b/src/main/java/com/example/qoocca_be/user/service/AuthService.java
@@ -73,6 +73,6 @@ public class AuthService {
         String role = jwtTokenProvider.getRoleFromToken(refreshToken);
         String newAccessToken = jwtTokenProvider.generateAccessToken(userId, role);
 
-        return new LoginResponseDto(newAccessToken, null);
+        return new LoginResponseDto(newAccessToken, refreshToken);
     }
 }


### PR DESCRIPTION
리프레시 토큰 값이 그대로 쿠키에 저장되는 것을 확인하고 수정을 시작했습니다.

HttpOnly를 사용해 토큰 탈취를 막고 있지만
추가적인 보안이 필요할 것 같아서 암호화하기로 결정했습니다.

AES 알고리즘을 사용해 refreshToken을 암호화해서 저장하고
복호화해서 사용하는 것으로 코드를 수정했습니다.

### 주요 수정 사함
CookieUtils 내에 AES-256 암호화/복호화 로직을 추가하여 저장소 내 토큰 노출을 차단
쿠키 설정에 SameSite(Lax)와 Path(/)를 명시하여 브라우저 간 전송 안정성을 확보

확인부탁드립다