### PR TITLE
fix/2 엔티티 수정

### DIFF
--- a/src/main/java/com/example/qoocca_be/academy/dto/AcademyResponseDto.java
+++ b/src/main/java/com/example/qoocca_be/academy/dto/AcademyResponseDto.java
@@ -21,6 +21,8 @@ public class AcademyResponseDto {
 
     private String name;
 
+    private String approvalStatus;
+
     private String address;
     private String baseAddress;
     private String detailAddress;
@@ -48,6 +50,7 @@ public class AcademyResponseDto {
         return AcademyResponseDto.builder()
                 .id(academy.getId())
                 .name(academy.getName())
+                .approvalStatus(academy.getApprovalStatus().name())
                 .address(academy.getAddress())
                 .baseAddress(academy.getBaseAddress())
                 .detailAddress(academy.getDetailAddress())

--- a/src/main/java/com/example/qoocca_be/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/qoocca_be/global/jwt/JwtTokenProvider.java
@@ -46,7 +46,10 @@ public class JwtTokenProvider {
 
         cookieUtils.addRefreshTokenCookie(res, refreshToken);
 
-        return new LoginResponseDto(accessToken, refreshToken);
+        return LoginResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(null)
+                .build();
     }
 
     public String generateAccessToken(Long userId, String role){

--- a/src/main/java/com/example/qoocca_be/user/controller/UserController.java
+++ b/src/main/java/com/example/qoocca_be/user/controller/UserController.java
@@ -14,7 +14,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,24 +34,21 @@ public class UserController {
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@Valid @RequestBody UserRequestDto req, HttpServletResponse res) {
         LoginResponseDto tokens = userService.signup(req, res);
-        cookieUtils.addRefreshTokenCookie(res, tokens.getRefreshToken());
-        return ResponseEntity.ok(new LoginResponseDto(tokens.getAccessToken(), null));
+        return ResponseEntity.ok(tokens);
     }
 
     @Operation(summary = "계정 연동")
     @PostMapping("/link-social")
     public ResponseEntity<?> linkSocial(@RequestBody SocialLinkRequestDto dto, HttpServletResponse res) {
         LoginResponseDto tokens = userService.linkSocialAccount(dto, res);
-
-        return ResponseEntity.ok(new LoginResponseDto(tokens.getAccessToken(), null));
+        return ResponseEntity.ok(tokens);
     }
 
     @Operation(summary = "로그인")
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto req, HttpServletResponse res) {
         LoginResponseDto tokens = authService.login(req, res);
-        cookieUtils.addRefreshTokenCookie(res, tokens.getRefreshToken());
-        return ResponseEntity.ok(new LoginResponseDto(tokens.getAccessToken(), null));
+        return ResponseEntity.ok(tokens);
     }
 
     @Operation(summary = "소셜 로그인")
@@ -61,7 +57,8 @@ public class UserController {
                                          @RequestBody Map<String, String> body,
                                          HttpServletResponse res) {
         String code = body.get("code");
-        return ResponseEntity.ok(authService.socialLogin(provider, code, res));
+        LoginResponseDto tokens = authService.socialLogin(provider, code, res);
+        return ResponseEntity.ok(tokens);
     }
 
     @Operation(summary = "Access Token 재발급")

--- a/src/main/java/com/example/qoocca_be/user/model/LoginResponseDto.java
+++ b/src/main/java/com/example/qoocca_be/user/model/LoginResponseDto.java
@@ -9,11 +9,7 @@ import lombok.*;
 @NoArgsConstructor
 public class LoginResponseDto {
     private String accessToken;
+    private Long academyId;
     private String refreshToken;
     private String socialId;
-
-    public LoginResponseDto(String accessToken, String refreshToken) {
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-    }
 }

--- a/src/main/java/com/example/qoocca_be/user/service/AuthService.java
+++ b/src/main/java/com/example/qoocca_be/user/service/AuthService.java
@@ -35,6 +35,7 @@ public class AuthService {
         return service.login(code, res);
     }
 
+    @Transactional(readOnly = true)
     public LoginResponseDto login(LoginRequestDto req, HttpServletResponse res) {
         UserEntity userEntity = userRepository.findByEmail(req.getEmail())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -43,7 +44,13 @@ public class AuthService {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
 
-        return jwtTokenProvider.generateTokens(userEntity.getId(), userEntity.getRole(), res);
+        LoginResponseDto tokens = jwtTokenProvider.generateTokens(userEntity.getId(), userEntity.getRole(), res);
+
+        return LoginResponseDto.builder()
+                .accessToken(tokens.getAccessToken())
+                .refreshToken(null)
+                .academyId(userEntity.getAcademies().isEmpty() ? null : userEntity.getAcademies().get(0).getId())
+                .build();
     }
 
     @Transactional
@@ -73,6 +80,13 @@ public class AuthService {
         String role = jwtTokenProvider.getRoleFromToken(refreshToken);
         String newAccessToken = jwtTokenProvider.generateAccessToken(userId, role);
 
-        return new LoginResponseDto(newAccessToken, refreshToken);
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return LoginResponseDto.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(refreshToken)
+                .academyId(user.getAcademies().isEmpty() ? null : user.getAcademies().get(0).getId())
+                .build();
     }
 }

--- a/src/main/java/com/example/qoocca_be/user/service/SocialOauthService.java
+++ b/src/main/java/com/example/qoocca_be/user/service/SocialOauthService.java
@@ -49,7 +49,16 @@ public abstract class SocialOauthService {
     private LoginResponseDto generateLoginResponse(UserEntity user, HttpServletResponse res) {
         LoginResponseDto loginRes = jwtTokenProvider.generateTokens(user.getId(), user.getRole(), res);
         cookieUtils.addRefreshTokenCookie(res, loginRes.getRefreshToken());
-        return new LoginResponseDto(loginRes.getAccessToken(), null);
+
+        Long academyId = null;
+        if (user.getAcademies() != null && !user.getAcademies().isEmpty()) {
+            academyId = user.getAcademies().get(0).getId();
+        }
+
+        return LoginResponseDto.builder()
+                .accessToken(loginRes.getAccessToken())
+                .academyId(academyId)
+                .build();
     }
 
     private LoginResponseDto needPhoneAuthResponse(String socialId) {


### PR DESCRIPTION
LoginResponseDto에 academyId 필드를 추가하여 로그인 성공 시 사용자의 대표 학원 ID를 반환하도록 수정했습니다.

AuthService 및 SocialOauthService 내 로그인 로직에서 사용자 엔티티와 연관된 학원 정보를 조회하여 응답에 포함시켰습니다.

refreshAccessToken 시에도 학원 식별 정보가 유실되지 않도록 응답 객체를 보강했습니다.