### PR TITLE
feature/18 Add ClassParentStats Code

### DIFF
--- a/src/main/java/com/example/qoocca_be/classInfo/controller/ClassParentStatsController.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/controller/ClassParentStatsController.java
@@ -1,0 +1,24 @@
+package com.example.qoocca_be.classInfo.controller;
+
+import com.example.qoocca_be.classInfo.model.ClassParentStatsResponseDTO;
+import com.example.qoocca_be.classInfo.service.ClassParentStatsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/academy/{academyId}/class")
+public class ClassParentStatsController {
+
+    private final ClassParentStatsService service;
+
+    @GetMapping("/parentstats")
+    public ResponseEntity<List<ClassParentStatsResponseDTO>> getParentStats(
+            @PathVariable Long academyId
+    ) {
+        return ResponseEntity.ok(service.getParentStats(academyId));
+    }
+}

--- a/src/main/java/com/example/qoocca_be/classInfo/model/ClassParentStatsResponseDTO.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/model/ClassParentStatsResponseDTO.java
@@ -1,0 +1,19 @@
+package com.example.qoocca_be.classInfo.model;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ClassParentStatsResponseDTO {
+
+    private Long classId;
+    private String className;
+    private List<ClassParentStudentDTO> students;
+
+    public ClassParentStatsResponseDTO(Long classId, String className, List<ClassParentStudentDTO> students) {
+        this.classId = classId;
+        this.className = className;
+        this.students = students;
+    }
+}

--- a/src/main/java/com/example/qoocca_be/classInfo/model/ClassParentStudentDTO.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/model/ClassParentStudentDTO.java
@@ -1,0 +1,16 @@
+package com.example.qoocca_be.classInfo.model;
+
+import com.example.qoocca_be.parent.model.ParentResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ClassParentStudentDTO {
+
+    private Long studentId;
+    private String studentName;
+    private List<ParentResponse> parents;
+}

--- a/src/main/java/com/example/qoocca_be/classInfo/repository/ClassParentStatsRepository.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/repository/ClassParentStatsRepository.java
@@ -1,0 +1,26 @@
+package com.example.qoocca_be.classInfo.repository;
+
+import com.example.qoocca_be.classInfo.entity.StudentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ClassParentStatsRepository extends JpaRepository<com.example.qoocca_be.classInfo.entity.ClassInfoEntity, Long> {
+
+    @Query("""
+        SELECT 
+            c,
+            s
+        FROM ClassInfoEntity c
+        JOIN ClassInfoStudentEntity cis ON cis.classInfo = c
+        JOIN StudentEntity s ON cis.student = s
+        WHERE c.academy.id = :academyId
+          AND (:status IS NULL OR cis.status = :status)
+    """)
+    List<Object[]> findStudentsByAcademy(
+            @Param("academyId") Long academyId,
+            @Param("status") StudentStatus status
+    );
+}

--- a/src/main/java/com/example/qoocca_be/classInfo/service/ClassParentStatsService.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/service/ClassParentStatsService.java
@@ -1,0 +1,85 @@
+package com.example.qoocca_be.classInfo.service;
+
+import com.example.qoocca_be.classInfo.entity.ClassInfoEntity;
+import com.example.qoocca_be.classInfo.entity.StudentStatus;
+import com.example.qoocca_be.classInfo.model.ClassParentStatsResponseDTO;
+import com.example.qoocca_be.classInfo.model.ClassParentStudentDTO;
+import com.example.qoocca_be.classInfo.repository.ClassParentStatsRepository;
+import com.example.qoocca_be.parent.model.ParentResponse;
+import com.example.qoocca_be.student.entity.StudentEntity;
+import com.example.qoocca_be.student.entity.StudentParentEntity;
+import com.example.qoocca_be.student.repository.StudentParentRepository;
+import com.example.qoocca_be.student.service.StudentParentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ClassParentStatsService {
+
+    private final ClassParentStatsRepository repository;
+    private final StudentParentService studentParentService;
+    private final StudentParentRepository studentParentRepository;
+
+    public List<ClassParentStatsResponseDTO> getParentStats(Long academyId) {
+
+        List<Object[]> rows = repository.findStudentsByAcademy(academyId, null);
+
+        Map<Long, ClassParentStatsResponseDTO> classMap = new LinkedHashMap<>();
+
+        // 1. 학생 ID 수집
+        List<Long> studentIds = rows.stream()
+                .map(r -> ((StudentEntity) r[1]).getStudentId())
+                .distinct()
+                .toList();
+
+        // 2. 부모정보 한번에 조회
+        List<StudentParentEntity> parentEntities =
+                studentParentRepository.findAllByStudentIdsWithParent(studentIds);
+
+        // 3. studentId → parents map 만들기
+        Map<Long, List<ParentResponse>> parentMap = parentEntities.stream()
+                .collect(Collectors.groupingBy(
+                        sp -> sp.getStudent().getStudentId(),
+                        Collectors.mapping(
+                                sp -> ParentResponse.from(sp.getParent()),
+                                Collectors.toList()
+                        )
+                ));
+
+        // 4. 반 + 학생 조립
+        for (Object[] row : rows) {
+            ClassInfoEntity classInfo = (ClassInfoEntity) row[0];
+            StudentEntity student = (StudentEntity) row[1];
+
+            classMap.putIfAbsent(
+                    classInfo.getClassId(),
+                    new ClassParentStatsResponseDTO(
+                            classInfo.getClassId(),
+                            classInfo.getClassName(),
+                            new ArrayList<>()
+                    )
+            );
+
+            List<ParentResponse> parents =
+                    parentMap.getOrDefault(student.getStudentId(), List.of());
+
+            ClassParentStudentDTO studentDTO =
+                    new ClassParentStudentDTO(
+                            student.getStudentId(),
+                            student.getStudentName(),
+                            parents
+                    );
+
+            classMap.get(classInfo.getClassId())
+                    .getStudents()
+                    .add(studentDTO);
+        }
+
+        return new ArrayList<>(classMap.values());
+    }
+}
+

--- a/src/main/java/com/example/qoocca_be/global/security/AcademyApprovalFilter.java
+++ b/src/main/java/com/example/qoocca_be/global/security/AcademyApprovalFilter.java
@@ -27,53 +27,56 @@ public class AcademyApprovalFilter extends OncePerRequestFilter {
     private final ObjectMapper objectMapper;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
             throws ServletException, IOException {
 
         String path = request.getRequestURI();
 
+        // 인증/공개 API는 패스
+        if (path.startsWith("/api/auth") ||
+                path.startsWith("/swagger") ||
+                path.startsWith("/v3/api-docs")) {
 
-        /*if (path.startsWith("/api/auth") ||
-                path.startsWith("/api/dashboard") ||
-                path.startsWith("/api/academy/register") ||
-                (path.startsWith("/api/academy/") && !path.contains("/class") && request.getMethod().equals("GET"))) {
-            filterChain.doFilter(request, response);
-            return;
-        }*/
-        if (path.startsWith("/api/")) {
             filterChain.doFilter(request, response);
             return;
         }
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication != null && authentication.isAuthenticated()) {
+        if (authentication != null && authentication.isAuthenticated()
+                && authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
 
-            if (authentication.getAuthorities().stream()
-                    .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))) {
+            // ✅ ADMIN 은 무조건 통과
+            boolean isAdmin = authentication.getAuthorities().stream()
+                    .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+
+            if (isAdmin) {
                 filterChain.doFilter(request, response);
                 return;
             }
 
-            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
             Long userId = userDetails.getUserId();
 
             Optional<AcademyEntity> academyOpt = academyRepository.findByUserId(userId);
 
-            if (academyOpt.isPresent()) {
-                AcademyEntity academy = academyOpt.get();
-                if (academy.getApprovalStatus() != ApprovalStatus.APPROVED) {
-                    sendErrorResponse(response, ErrorCode.ACADEMY_NOT_APPROVED);
-                    return;
-                }
-            } else {
+            if (academyOpt.isEmpty()) {
                 sendErrorResponse(response, ErrorCode.ACADEMY_NOT_FOUND);
+                return;
+            }
+
+            AcademyEntity academy = academyOpt.get();
+
+            if (academy.getApprovalStatus() != ApprovalStatus.APPROVED) {
+                sendErrorResponse(response, ErrorCode.ACADEMY_NOT_APPROVED);
                 return;
             }
         }
 
         filterChain.doFilter(request, response);
     }
+
 
     private void sendErrorResponse(HttpServletResponse res, ErrorCode errorCode) throws IOException {
         res.setStatus(errorCode.getStatus());

--- a/src/main/java/com/example/qoocca_be/student/repository/StudentParentRepository.java
+++ b/src/main/java/com/example/qoocca_be/student/repository/StudentParentRepository.java
@@ -3,6 +3,7 @@ package com.example.qoocca_be.student.repository;
 import com.example.qoocca_be.student.entity.StudentParentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -50,9 +51,23 @@ public interface StudentParentRepository
     """)
     List<Long> findParentIdsByStudentId(Long studentId);
 
-    /* =========================
-     * 삭제
-     * ========================= */
+
+
+    //학생한명당 부모조회를 하는 N+1 문제 해결하기 위한 메서드
+    //여러학생 ID 에 대해 부모정보를 한번에 조회한다. ParentEntity도 같이 로딩한다.
+
+    @Query("""
+    SELECT sp
+    FROM StudentParentEntity sp
+    JOIN FETCH sp.parent
+    WHERE sp.student.studentId IN :studentIds
+""")
+    List<StudentParentEntity> findAllByStudentIdsWithParent(
+            @Param("studentIds") List<Long> studentIds
+    );
+
+
+
 
     // 학생 기준 전체 부모 연결 삭제 (학생 삭제 시)
     void deleteByStudent_StudentId(Long studentId);


### PR DESCRIPTION
#35 

학원별 클래스마다 현재 소속된 학생들과 해당 학생의 보호자 정보(카드번호 포함)를 조회하는 API를 추가했습니다.

### 신규 API
GET /api/academy/{academyId}/class/parentstats

### 응답 구조
- 반(class)
  - 학생(student)
    - 보호자 목록(parent, 카드정보 포함)

---

## 📂 추가된 패키지 구조

com.example.qoocca_be.classInfo  
├─ controller  
│   └─ ClassInfoParentStatsController.java  
├─ service  
│   └─ ClassInfoParentStatsService.java  
├─ repository  
│   └─ ClassInfoParentStatsRepository.java  
└─ model  
    ├─ ClassParentStatsResponseDTO.java  
    └─ StudentWithParentsDTO.java  

---

## ⚙️ 구현 요약

- 반 + 학생 정보: ClassInfoParentStatsRepository에서 조회
- 보호자 정보:
  - StudentParentRepository의 `findAllByStudentIdsWithParent()` 사용
  - JOIN FETCH로 부모 엔티티를 한번에 로딩하여 N+1 문제 방지
- Service 단에서:
  - studentId 기준으로 부모 데이터를 Map으로 변환
  - 반 → 학생 → 보호자 구조로 DTO 조립

---

## 🚀 기대 효과

- 학생 수가 많아도 부모 조회 쿼리 1번으로 처리 (N+1 방지)
- 기존 `/api/student/{id}/parent` API와 데이터 구조 일관성 유지
- 프론트에서 반 단위로 데이터 렌더링 가능

---

## 🔍 테스트

- academyId 기준 정상 조회 확인
- 보호자가 없는 학생도 빈 배열로 응답 확인
- 학생 수가 많은 경우 쿼리 2회만 발생 확인

## 👀 코드리뷰 요청사항

특히 아래 부분 위주로 확인 부탁드립니다 

### 1️⃣ 쿼리 설계 적절성
- ClassInfoParentStatsRepository의 반+학생 조회 쿼리 구조가 적절한지
- StudentParentRepository의 JOIN FETCH 사용 방식이 괜찮은지

### 2️⃣ N+1 방지 로직
- Service에서 studentId 수집 → 부모 일괄 조회 → Map 변환 방식이 적절한지
- 더 깔끔하거나 효율적인 방법이 있는지 의견 부탁드립니다

### 3️⃣ DTO 구조
- ClassParentStatsResponseDTO / StudentWithParentsDTO 구조가 프론트 사용에 적합한지
- 필드 네이밍이나 계층 구조 개선 포인트 있는지

### 4️⃣ 예외 케이스
- 학생이 없을 때
- 보호자가 없는 학생
- 클래스만 있고 학생이 없는 경우 처리 방식

### 5️⃣ 확장성
- 향후 페이징, 필터(재학/퇴학) 추가 시 구조 유지 가능한지

피드백 주시면 반영해서 개선하겠습니다 ^^

Closes #35 