### PR TITLE
feature/19 대시보드 오늘 수업 필터링 및 수납 관리 인증 로직 강화

### DIFF
--- a/src/main/java/com/example/qoocca_be/academy/controller/AcademyController.java
+++ b/src/main/java/com/example/qoocca_be/academy/controller/AcademyController.java
@@ -18,7 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.nio.file.attribute.UserPrincipal;
 import java.util.List;
 
 @Tag(name = "Academy API", description = "학원 관련 API")

--- a/src/main/java/com/example/qoocca_be/academy/controller/AcademyStudentController.java
+++ b/src/main/java/com/example/qoocca_be/academy/controller/AcademyStudentController.java
@@ -2,7 +2,6 @@ package com.example.qoocca_be.academy.controller;
 
 import com.example.qoocca_be.academy.dto.AcademyStudentCreateRequest;
 import com.example.qoocca_be.academy.dto.AcademyStudentResponse;
-import com.example.qoocca_be.academy.dto.DashboardStatsResponse;
 import com.example.qoocca_be.academy.service.AcademyStudentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/qoocca_be/academy/service/AcademyStudentService.java
+++ b/src/main/java/com/example/qoocca_be/academy/service/AcademyStudentService.java
@@ -2,26 +2,16 @@ package com.example.qoocca_be.academy.service;
 
 import com.example.qoocca_be.academy.dto.AcademyStudentCreateRequest;
 import com.example.qoocca_be.academy.dto.AcademyStudentResponse;
-import com.example.qoocca_be.academy.dto.DashboardStatsResponse;
 import com.example.qoocca_be.academy.entity.AcademyEntity;
 import com.example.qoocca_be.academy.entity.AcademyStudentEntity;
 import com.example.qoocca_be.academy.repository.AcademyRepository;
 import com.example.qoocca_be.academy.repository.AcademyStudentRepository;
-import com.example.qoocca_be.attendance.entity.AttendanceEntity;
-import com.example.qoocca_be.attendance.repository.AttendanceRepository;
-import com.example.qoocca_be.classInfo.entity.StudentStatus;
-import com.example.qoocca_be.classInfo.repository.ClassInfoRepository;
-import com.example.qoocca_be.classInfo.repository.ClassInfoStudentRepository;
-import com.example.qoocca_be.classInfo.service.ClassInfoService;
-import com.example.qoocca_be.receipt.repository.ReceiptRepository;
 import com.example.qoocca_be.student.entity.StudentEntity;
 import com.example.qoocca_be.student.repository.StudentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service

--- a/src/main/java/com/example/qoocca_be/classInfo/entity/ClassInfoEntity.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/entity/ClassInfoEntity.java
@@ -11,8 +11,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @EntityListeners(AuditingEntityListener.class)
 @Getter
@@ -72,7 +70,7 @@ public class ClassInfoEntity {
      * 기타
      * ========================= */
     @Column(name = "price")
-    private String price;
+    private Long price;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)

--- a/src/main/java/com/example/qoocca_be/classInfo/model/ClassGetResponse.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/model/ClassGetResponse.java
@@ -27,7 +27,7 @@ public class ClassGetResponse {
     private boolean saturday;
     private boolean sunday;
 
-    private String price;
+    private Long price;
     private String ageCode;
     private String subjectName;
 

--- a/src/main/java/com/example/qoocca_be/classInfo/model/ClassInfoStudentRequestDTO.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/model/ClassInfoStudentRequestDTO.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 public class ClassInfoStudentRequestDTO {
 
-    @Schema(description = "등록할 기존 학생 ID", example = "1", required = true)
+    @Schema(description = "등록할 기존 학생 ID", example = "1")
     private Long studentId;
 }

--- a/src/main/java/com/example/qoocca_be/classInfo/model/ClassPostRequest.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/model/ClassPostRequest.java
@@ -50,7 +50,7 @@ public class ClassPostRequest {
     private boolean sunday;
 
     @Schema(description = "수업 가격 (원)", example = "600000")
-    private String price;
+    private Long price;
 
     @Schema(description = "연령 ID (age 테이블 PK)", example = "2")
     private Long ageId;

--- a/src/main/java/com/example/qoocca_be/classInfo/repository/ClassInfoRepository.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/repository/ClassInfoRepository.java
@@ -29,11 +29,21 @@ public interface ClassInfoRepository extends JpaRepository<ClassInfoEntity, Long
          AND a.classInfo.classId = c.classId 
          AND a.attendanceDate = :today
     WHERE c.academy.id = :academyId
+      AND (
+          (:dayName = 'MONDAY' AND c.monday = true) OR
+          (:dayName = 'TUESDAY' AND c.tuesday = true) OR
+          (:dayName = 'WEDNESDAY' AND c.wednesday = true) OR
+          (:dayName = 'THURSDAY' AND c.thursday = true) OR
+          (:dayName = 'FRIDAY' AND c.friday = true) OR
+          (:dayName = 'SATURDAY' AND c.saturday = true) OR
+          (:dayName = 'SUNDAY' AND c.sunday = true)
+      )
     GROUP BY c.classId, c.className
 """)
     List<ClassSummaryResponse> findDashboardSummaries(
             @Param("academyId") Long academyId,
             @Param("today") LocalDate today,
+            @Param("dayName") String dayName,
             @Param("status") StudentStatus status
     );
 }

--- a/src/main/java/com/example/qoocca_be/classInfo/repository/ClassInfoStatsRepository.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/repository/ClassInfoStatsRepository.java
@@ -1,7 +1,6 @@
 package com.example.qoocca_be.classInfo.repository;
 
 import com.example.qoocca_be.classInfo.entity.ClassInfoEntity;
-import com.example.qoocca_be.classInfo.entity.ClassInfoStudentEntity;
 import com.example.qoocca_be.classInfo.model.ClassStatsProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/example/qoocca_be/classInfo/service/ClassInfoService.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/service/ClassInfoService.java
@@ -79,6 +79,14 @@ public class ClassInfoService {
 
     @Transactional(readOnly = true)
     public List<ClassSummaryResponse> getAcademyDashboard(Long academyId) {
-        return classInfoRepository.findDashboardSummaries(academyId, LocalDate.now(), StudentStatus.ENROLLED);
+        LocalDate today = LocalDate.now();
+        String dayName = today.getDayOfWeek().name();
+
+        return classInfoRepository.findDashboardSummaries(
+                academyId,
+                today,
+                dayName,
+                StudentStatus.ENROLLED
+        );
     }
 }

--- a/src/main/java/com/example/qoocca_be/classInfo/service/ClassParentStatsService.java
+++ b/src/main/java/com/example/qoocca_be/classInfo/service/ClassParentStatsService.java
@@ -1,7 +1,6 @@
 package com.example.qoocca_be.classInfo.service;
 
 import com.example.qoocca_be.classInfo.entity.ClassInfoEntity;
-import com.example.qoocca_be.classInfo.entity.StudentStatus;
 import com.example.qoocca_be.classInfo.model.ClassParentStatsResponseDTO;
 import com.example.qoocca_be.classInfo.model.ClassParentStudentDTO;
 import com.example.qoocca_be.classInfo.repository.ClassParentStatsRepository;
@@ -9,7 +8,6 @@ import com.example.qoocca_be.parent.model.ParentResponse;
 import com.example.qoocca_be.student.entity.StudentEntity;
 import com.example.qoocca_be.student.entity.StudentParentEntity;
 import com.example.qoocca_be.student.repository.StudentParentRepository;
-import com.example.qoocca_be.student.service.StudentParentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,7 +19,6 @@ import java.util.stream.Collectors;
 public class ClassParentStatsService {
 
     private final ClassParentStatsRepository repository;
-    private final StudentParentService studentParentService;
     private final StudentParentRepository studentParentRepository;
 
     public List<ClassParentStatsResponseDTO> getParentStats(Long academyId) {

--- a/src/main/java/com/example/qoocca_be/receipt/controller/ReceiptClassController.java
+++ b/src/main/java/com/example/qoocca_be/receipt/controller/ReceiptClassController.java
@@ -1,8 +1,10 @@
 package com.example.qoocca_be.receipt.controller;
 
 import com.example.qoocca_be.receipt.model.ClassPaymentSummaryResponse;
+import com.example.qoocca_be.receipt.model.DashboardMainSummaryResponse;
 import com.example.qoocca_be.receipt.service.ReceiptService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,5 +23,14 @@ public class ReceiptClassController {
             @RequestParam int month
     ) {
         return receiptService.getClassReceiptSummary(academyId, year, month);
+    }
+
+    @GetMapping("/{academyId}/receipt/dashboard-main")
+    public ResponseEntity<List<DashboardMainSummaryResponse>> getDashboardMainSummary(
+            @PathVariable Long academyId,
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        return ResponseEntity.ok(receiptService.getDashboardMainSummary(academyId, year, month));
     }
 }

--- a/src/main/java/com/example/qoocca_be/receipt/model/DashboardMainSummaryResponse.java
+++ b/src/main/java/com/example/qoocca_be/receipt/model/DashboardMainSummaryResponse.java
@@ -1,0 +1,16 @@
+package com.example.qoocca_be.receipt.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DashboardMainSummaryResponse {
+    private String className;
+    private String classTime;
+    private String status;
+    private String statusLabel;
+    private Long totalAmount;
+}

--- a/src/main/java/com/example/qoocca_be/receipt/service/ReceiptService.java
+++ b/src/main/java/com/example/qoocca_be/receipt/service/ReceiptService.java
@@ -2,7 +2,6 @@ package com.example.qoocca_be.receipt.service;
 
 import com.example.qoocca_be.classInfo.entity.ClassInfoEntity;
 import com.example.qoocca_be.classInfo.entity.ClassInfoStudentEntity;
-import com.example.qoocca_be.classInfo.entity.StudentStatus;
 import com.example.qoocca_be.classInfo.repository.ClassInfoRepository;
 import com.example.qoocca_be.classInfo.repository.ClassInfoStudentRepository;
 import com.example.qoocca_be.receipt.entity.ReceiptEntity;
@@ -17,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -149,7 +149,7 @@ public class ReceiptService {
                 return ClassPaymentSummaryResponse.StudentPaymentDetail.builder()
                         .studentId(enroll.getStudent().getStudentId())
                         .studentName(enroll.getStudent().getStudentName())
-                        .amount(Long.valueOf(cls.getPrice())) // price -> 추후 Long으로 바꿀 수 있으면 바꾸기
+                        .amount(cls.getPrice())
                         .status(status)
                         .build();
             }).collect(Collectors.toList());
@@ -168,5 +168,71 @@ public class ReceiptService {
                     .students(studentDetails) // 상세 명단 포함
                     .build();
         }).collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<DashboardMainSummaryResponse> getDashboardMainSummary(Long academyId, int year, int month) {
+        // 1. 해당 학원의 모든 클래스 조회
+        List<ClassInfoEntity> classList = classInfoRepository.findByAcademy_Id(academyId);
+
+        YearMonth ym = YearMonth.of(year, month);
+        LocalDateTime start = ym.atDay(1).atStartOfDay();
+        LocalDateTime end = ym.atEndOfMonth().atTime(23, 59, 59);
+
+        return classList.stream().map(cls -> {
+            // 2. 해당 클래스의 재원생 및 수납 기록 조회
+            List<ClassInfoStudentEntity> enrollments = classInfoStudentRepository.findByClassInfo_ClassId(cls.getClassId());
+            List<ReceiptEntity> receipts = receiptRepository.findByClassInfo_ClassIdAndReceiptDateBetween(
+                    cls.getClassId(), start, end);
+
+            // 3. 대표 상태 결정 (기존 로직 활용)
+            String repStatus = determineRepresentativeStatus(enrollments, receipts);
+
+            return DashboardMainSummaryResponse.builder()
+                    .className(cls.getClassName())
+                    .classTime(cls.getStartTime() + "~" + cls.getEndTime())
+                    .status(repStatus)
+                    .statusLabel(getStatusLabel(repStatus))
+                    .totalAmount(cls.getPrice() * enrollments.size())
+                    .build();
+        }).collect(Collectors.toList());
+    }
+
+    private String determineRepresentativeStatus(List<ClassInfoStudentEntity> enrollments, List<ReceiptEntity> receipts) {
+        if (enrollments.isEmpty()) return "PAID";
+
+        Map<Long, String> studentStatusMap = receipts.stream()
+                .collect(Collectors.toMap(
+                        r -> r.getStudent().getStudentId(),
+                        r -> r.getReceiptStatus().name(),
+                        (existing, replacement) -> existing // 중복 시 기존값 유지
+                ));
+
+        boolean hasIssued = false;
+        int paidCount = 0;
+
+        for (ClassInfoStudentEntity enrollment : enrollments) {
+            String status = studentStatusMap.getOrDefault(enrollment.getStudent().getStudentId(), "BEFORE_REQUEST");
+
+            switch (status) {
+                case "BEFORE_REQUEST" -> {
+                    return "BEFORE_REQUEST";
+                }
+                case "ISSUED" -> hasIssued = true;
+                case "PAID" -> paidCount++;
+            }
+        }
+
+        if (hasIssued) return "ISSUED";
+        return "PAID";
+    }
+
+    private String getStatusLabel(String status) {
+        return switch (status) {
+            case "BEFORE_REQUEST" -> "요청 전";
+            case "ISSUED" -> "결제 대기";
+            case "PAID" -> "결제 완료";
+            default -> status;
+        };
     }
 }

--- a/src/main/java/com/example/qoocca_be/student/entity/StudentEntity.java
+++ b/src/main/java/com/example/qoocca_be/student/entity/StudentEntity.java
@@ -1,8 +1,6 @@
 package com.example.qoocca_be.student.entity;
 
 import com.example.qoocca_be.academy.entity.AcademyStudentEntity;
-import com.example.qoocca_be.classInfo.entity.ClassInfoEntity;
-import com.example.qoocca_be.classInfo.entity.StudentStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -51,6 +49,7 @@ public class StudentEntity {
 
 
     @OneToMany(mappedBy = "student")
+    @Builder.Default
     private List<AcademyStudentEntity> academyStudents = new ArrayList<>();
 
 

--- a/src/main/java/com/example/qoocca_be/student/model/StudentCreateRequest.java
+++ b/src/main/java/com/example/qoocca_be/student/model/StudentCreateRequest.java
@@ -1,7 +1,5 @@
 package com.example.qoocca_be.student.model;
 
-import com.example.qoocca_be.classInfo.entity.StudentStatus;
-import com.example.qoocca_be.student.entity.StudentEntity;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 

--- a/src/main/java/com/example/qoocca_be/student/model/StudentResponse.java
+++ b/src/main/java/com/example/qoocca_be/student/model/StudentResponse.java
@@ -1,6 +1,5 @@
 package com.example.qoocca_be.student.model;
 
-import com.example.qoocca_be.classInfo.entity.StudentStatus;
 import com.example.qoocca_be.student.entity.StudentEntity;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/example/qoocca_be/student/repository/StudentRepository.java
+++ b/src/main/java/com/example/qoocca_be/student/repository/StudentRepository.java
@@ -5,9 +5,6 @@ import com.example.qoocca_be.student.entity.StudentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
 public interface StudentRepository
         extends JpaRepository<StudentEntity, Long> {

--- a/src/main/java/com/example/qoocca_be/student/service/StudentService.java
+++ b/src/main/java/com/example/qoocca_be/student/service/StudentService.java
@@ -1,6 +1,5 @@
 package com.example.qoocca_be.student.service;
 
-import com.example.qoocca_be.classInfo.entity.StudentStatus;
 import com.example.qoocca_be.student.entity.StudentEntity;
 import com.example.qoocca_be.student.model.StudentCreateRequest;
 import com.example.qoocca_be.student.model.StudentResponse;

--- a/src/main/java/com/example/qoocca_be/user/model/RedisDao.java
+++ b/src/main/java/com/example/qoocca_be/user/model/RedisDao.java
@@ -9,11 +9,11 @@ import java.time.Duration;
 @Component
 public class RedisDao {
 
-    private final RedisTemplate<String,String> redisTemplate;
-    private final ValueOperations<String,String> values;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ValueOperations<String, Object> values;
 
     public RedisDao(RedisTemplate<String, Object> redisTemplate) {
-        this.redisTemplate = (RedisTemplate<String, String>) (Object) redisTemplate;
+        this.redisTemplate = redisTemplate;
         this.values = this.redisTemplate.opsForValue();
     }
 

--- a/src/main/java/com/example/qoocca_be/user/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/qoocca_be/user/service/KakaoOAuthService.java
@@ -8,6 +8,7 @@ import com.example.qoocca_be.user.repository.UserRepository;
 import com.example.qoocca_be.global.jwt.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -85,6 +86,6 @@ public class KakaoOAuthService extends SocialOauthService {
         headers.setBearerAuth(accessToken);
 
         HttpEntity<?> request = new HttpEntity<>(headers);
-        return (Map<String, Object>) restTemplate.exchange(userInfoUrl, HttpMethod.GET, request, Map.class).getBody();
+        return restTemplate.exchange(userInfoUrl, HttpMethod.GET, request, new ParameterizedTypeReference<Map<String, Object>>() {}).getBody();
     }
 }

--- a/src/main/java/com/example/qoocca_be/user/service/NaverOauthService.java
+++ b/src/main/java/com/example/qoocca_be/user/service/NaverOauthService.java
@@ -8,6 +8,7 @@ import com.example.qoocca_be.user.repository.UserRepository;
 import com.example.qoocca_be.global.jwt.JwtTokenProvider;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -39,6 +40,7 @@ public class NaverOauthService extends SocialOauthService {
         String naverAccessToken = getNaverAccessToken(code);
 
         Map<String, Object> userInfo = getNaverUserInfo(naverAccessToken);
+        @SuppressWarnings("unchecked")
         Map<String, Object> naverResponse = (Map<String, Object>) userInfo.get("response");
 
         String naverId = String.valueOf(naverResponse.get("id"));
@@ -80,7 +82,12 @@ public class NaverOauthService extends SocialOauthService {
         params.add("code", code);
 
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
-        ResponseEntity<Map> response = restTemplate.postForEntity(tokenUrl, request, Map.class);
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                tokenUrl,
+                HttpMethod.POST,
+                request,
+                new ParameterizedTypeReference<Map<String, Object>>() {}
+        );
 
         return (String) response.getBody().get("access_token");
     }
@@ -91,8 +98,13 @@ public class NaverOauthService extends SocialOauthService {
         headers.setBearerAuth(accessToken);
 
         HttpEntity<?> request = new HttpEntity<>(headers);
-        ResponseEntity<Map> response = restTemplate.exchange(userInfoUrl, HttpMethod.GET, request, Map.class);
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                userInfoUrl,
+                HttpMethod.GET,
+                request,
+                new ParameterizedTypeReference<Map<String, Object>>() {}
+        );
 
-        return (Map<String, Object>) response.getBody();
+        return response.getBody();
     }
 }


### PR DESCRIPTION
**대시보드 "오늘의 수업" 자동 필터링**
학원의 모든 클래스가 대시보드에 다 나와서 보기가 힘들었습니다.
서버 시간을 기준으로 **오늘 요일(월~일)**을 체크해서, 오늘 수업이 있는 반만 쏙 골라 보여주도록 쿼리를 수정했습니다.
담당자가 출근해서 대시보드를 열면 '오늘 출석체크 해야 할 반'만 바로 보입니다.

ClassInfoRepository의 findDashboardSummaries 쿼리문 수정

**대시보드 수납 요약 api**
/api/academy/{academyId}/receipt/dashboard-main
<img width="722" height="263" alt="image" src="https://github.com/user-attachments/assets/e42d7f6c-3e66-4b1c-9dea-1026f801d902" />

**classInfo 엔티티 수정**
기존엔 price가 string으로 되어있었는데 이를 Long으로 바꿈
곱하기 등의 연산을 할 일이 좀 있어 수정했음

Closes #38 