### PR TITLE
feature/20  학생 등록 폼을 위한 Parent, Student 엔터티 수정

### DIFF
--- a/src/main/java/com/example/qoocca_be/academy/dto/AcademyStudentCreateRequest.java
+++ b/src/main/java/com/example/qoocca_be/academy/dto/AcademyStudentCreateRequest.java
@@ -10,4 +10,8 @@ public class AcademyStudentCreateRequest {
 
     @NotBlank
     private String studentName;
+
+    // ✅ 추가
+    @NotBlank
+    private String studentPhone;
 }

--- a/src/main/java/com/example/qoocca_be/academy/service/AcademyStudentService.java
+++ b/src/main/java/com/example/qoocca_be/academy/service/AcademyStudentService.java
@@ -31,8 +31,11 @@ public class AcademyStudentService {
         AcademyEntity academy = academyRepository.findById(academyId)
                 .orElseThrow(() -> new IllegalArgumentException("학원 없음"));
 
+        // ✅ 전화번호까지 저장
         StudentEntity student = StudentEntity.builder()
-                .studentName(request.getStudentName()).build();
+                .studentName(request.getStudentName())
+                .studentPhone(request.getStudentPhone())
+                .build();
 
         studentRepository.save(student);
 

--- a/src/main/java/com/example/qoocca_be/parent/entity/ParentEntity.java
+++ b/src/main/java/com/example/qoocca_be/parent/entity/ParentEntity.java
@@ -33,6 +33,10 @@ public class ParentEntity {
     /* =========================
      * 부모 정보
      * ========================= */
+
+    @Column(name = "parent_name")   // ✅ 추가
+    private String parentName;
+
     @Column(name = "card_num")
     private String cardNum;
 

--- a/src/main/java/com/example/qoocca_be/parent/model/ParentCreateRequest.java
+++ b/src/main/java/com/example/qoocca_be/parent/model/ParentCreateRequest.java
@@ -14,6 +14,9 @@ import lombok.NoArgsConstructor;
 public class ParentCreateRequest {
 
     @NotBlank
+    private String parentName;   // ✅ 추가
+
+    @NotBlank
     private String cardNum;
 
     @NotNull

--- a/src/main/java/com/example/qoocca_be/parent/model/ParentResponse.java
+++ b/src/main/java/com/example/qoocca_be/parent/model/ParentResponse.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 public class ParentResponse {
 
     private Long parentId;
+    private String parentName;   // ✅ 추가
     private String cardNum;
     private Boolean cardState;
     private String parentRelationship;
@@ -23,6 +24,7 @@ public class ParentResponse {
     public static ParentResponse from(ParentEntity entity) {
         return ParentResponse.builder()
                 .parentId(entity.getParentId())
+                .parentName(entity.getParentName())   // ✅ 추가
                 .cardNum(entity.getCardNum())
                 .cardState(entity.getCardState())
                 .parentRelationship(entity.getParentRelationship())

--- a/src/main/java/com/example/qoocca_be/parent/model/ParentUpdateRequest.java
+++ b/src/main/java/com/example/qoocca_be/parent/model/ParentUpdateRequest.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ParentUpdateRequest {
 
+    private String parentName;   // ✅ 추가
     private String cardNum;
     private Boolean cardState;
     private String parentRelationship;

--- a/src/main/java/com/example/qoocca_be/student/entity/StudentEntity.java
+++ b/src/main/java/com/example/qoocca_be/student/entity/StudentEntity.java
@@ -38,6 +38,11 @@ public class StudentEntity {
     @Column(name = "student_name")
     private String studentName;
 
+    // ✅ 추가
+    @Column(name = "student_phone")
+    private String studentPhone;
+
+
     /* =========================
      * 생성 / 수정일
      * ========================= */

--- a/src/main/java/com/example/qoocca_be/student/model/StudentCreateRequest.java
+++ b/src/main/java/com/example/qoocca_be/student/model/StudentCreateRequest.java
@@ -10,4 +10,7 @@ public class StudentCreateRequest {
     @NotBlank
     private String studentName;
 
+    @NotBlank
+    private String studentPhone;   // ✅ 추가
+
 }

--- a/src/main/java/com/example/qoocca_be/student/service/StudentParentService.java
+++ b/src/main/java/com/example/qoocca_be/student/service/StudentParentService.java
@@ -9,6 +9,8 @@ import com.example.qoocca_be.student.entity.StudentEntity;
 import com.example.qoocca_be.student.entity.StudentParentEntity;
 import com.example.qoocca_be.student.repository.StudentParentRepository;
 import com.example.qoocca_be.student.repository.StudentRepository;
+import jakarta.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,26 +27,20 @@ public class StudentParentService {
     private final ParentRepository parentRepository;
     private final StudentRepository studentRepository;
 
-    /* =========================
-     * GET: 학생의 부모 리스트 조회
-     * ========================= */
     public List<ParentResponse> getParents(Long studentId) {
-        List<StudentParentEntity> studentParents = studentParentRepository.findByStudent_StudentId(studentId);
-        return studentParents.stream()
+        return studentParentRepository.findByStudent_StudentId(studentId)
+                .stream()
                 .map(sp -> ParentResponse.from(sp.getParent()))
                 .collect(Collectors.toList());
     }
 
-    /* =========================
-     * POST: 학생-부모 연결 생성
-     * ========================= */
     public ParentResponse addParent(Long studentId, ParentCreateRequest request) {
-        // 1. 학생 존재 확인
+
         StudentEntity student = studentRepository.findById(studentId)
                 .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다. id=" + studentId));
 
-        // 2. 부모 저장
         ParentEntity parent = ParentEntity.builder()
+                .parentName(request.getParentName())      // ✅ 추가
                 .cardNum(request.getCardNum())
                 .cardState(request.getCardState())
                 .parentRelationship(request.getParentRelationship())
@@ -52,29 +48,28 @@ public class StudentParentService {
                 .isPay(request.getIsPay())
                 .alarm(request.getAlarm())
                 .build();
-        parent = parentRepository.save(parent);
 
-        // 3. 학생-부모 연결
+        parentRepository.save(parent);
+
         StudentParentEntity studentParent = StudentParentEntity.builder()
                 .student(student)
                 .parent(parent)
                 .build();
+
         studentParentRepository.save(studentParent);
 
         return ParentResponse.from(parent);
     }
 
-    /* =========================
-     * PUT: 부모 정보 수정
-     * ========================= */
     public ParentResponse updateParent(Long studentId, Long parentId, ParentUpdateRequest request) {
-        // 1. 학생-부모 관계 존재 확인
-        StudentParentEntity sp = studentParentRepository.findByStudent_StudentIdAndParent_ParentId(studentId, parentId)
+
+        StudentParentEntity sp = studentParentRepository
+                .findByStudent_StudentIdAndParent_ParentId(studentId, parentId)
                 .orElseThrow(() -> new IllegalArgumentException("학생-부모 관계를 찾을 수 없습니다."));
 
         ParentEntity parent = sp.getParent();
 
-        // 2. 수정
+        if (request.getParentName() != null) parent.setParentName(request.getParentName());   // ✅ 추가
         if (request.getCardNum() != null) parent.setCardNum(request.getCardNum());
         if (request.getCardState() != null) parent.setCardState(request.getCardState());
         if (request.getParentRelationship() != null) parent.setParentRelationship(request.getParentRelationship());

--- a/src/main/java/com/example/qoocca_be/student/service/StudentService.java
+++ b/src/main/java/com/example/qoocca_be/student/service/StudentService.java
@@ -20,11 +20,13 @@ public class StudentService {
 
         StudentEntity student = StudentEntity.builder()
                 .studentName(request.getStudentName())
+                .studentPhone(request.getStudentPhone()) // ✅ 추가
                 .build();
 
         studentRepository.save(student);
         return StudentResponse.from(student);
     }
+
 
     @Transactional(readOnly = true)
     public StudentResponse get(Long studentId) {
@@ -43,8 +45,13 @@ public class StudentService {
             student.setStudentName(request.getStudentName());
         }
 
+        if (request.getStudentPhone() != null) {          // ✅ 추가
+            student.setStudentPhone(request.getStudentPhone());
+        }
+
         return StudentResponse.from(student);
     }
+
 
     public void delete(Long studentId) {
         StudentEntity student = studentRepository.findById(studentId)


### PR DESCRIPTION
 학생 등록 기능 관련 백엔드 모델 보완

프론트엔드 학생 등록 폼 구현 과정에서, 기존 백엔드 엔터티/DTO에 일부 필드가 누락되어 데이터 저장이 불가능한 문제가 확인되어 관련 모델을 수정했습니다.

1. 학생 전화번호 필드 추가

프론트 학생 등록 폼에 studentPhone 입력값이 있으나, 기존 모델에 해당 필드가 없어 DB에 저장되지 않는 문제가 있었습니다.

변경 내용

StudentEntity
→ studentPhone 필드 추가

AcademyStudentCreateRequest DTO
→ studentPhone 필드 추가

2. 보호자 이름 필드 추가

프론트 보호자 등록 폼에 parentName 입력값이 있으나, 기존 ParentEntity 및 생성 DTO에 해당 필드가 없어 저장이 불가능한 상태였습니다.

변경 내용

ParentEntity
→ parentName 필드 추가

ParentCreateRequest DTO
→ parentName 필드 추가

학생-보호자 관계 테이블(StudentParentEntity)은 단순 매핑 역할이므로 필드 추가 없이 기존 구조를 유지했습니다.

💡 변경 이유

프론트 입력 폼과 백엔드 모델 간 필드 불일치 해소

학생 등록 → 보호자/카드 등록 → 반 배정의 3단계 API 플로우 정상 동작 보장

추후 보호자 정보 수정, 카드 변경 등 기능 확장 대비

간단한 작업이었지만, api 테스트 문제 없는지 확인부탁드립니다^^