### PR TITLE
feat: add excel upload api with ai header mapping

### DIFF
--- a/qoocca-api/build.gradle
+++ b/qoocca-api/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.github.cdimascio:dotenv-java:3.0.0'
+    implementation 'org.apache.poi:poi-ooxml:5.2.5'
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/controller/AcademyStudentController.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/controller/AcademyStudentController.java
@@ -3,13 +3,17 @@ package com.qoocca.teachers.api.academy.controller;
 import com.qoocca.teachers.api.academy.model.request.AcademyStudentCreateRequest;
 import com.qoocca.teachers.api.academy.model.request.AcademyStudentModifyRequest;
 import com.qoocca.teachers.api.academy.model.response.AcademyStudentResponse;
+import com.qoocca.teachers.api.academy.model.response.AcademyStudentUploadResponse;
 import com.qoocca.teachers.api.academy.service.AcademyStudentService;
+import com.qoocca.teachers.api.academy.service.AcademyStudentUploadService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -20,6 +24,7 @@ import java.util.List;
 public class AcademyStudentController {
 
     private final AcademyStudentService academyStudentService;
+    private final AcademyStudentUploadService academyStudentUploadService;
 
     @Operation(summary = "학원 원생 등록", description = "특정 학원에 새로운 학생을 등록합니다.")
     @PostMapping
@@ -61,4 +66,30 @@ public class AcademyStudentController {
     ) {
         academyStudentService.deleteStudent(academyId, studentId);
     }
+
+
+    @PostMapping(
+            value = "/upload",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    @Operation(summary = "엑셀 업로드 원생 등록", description = "엑셀 파일로 원생을 등록하고 클래스에 배정합니다.")
+    public AcademyStudentUploadResponse upload(
+            @Parameter(description = "학원 고유 ID", example = "1")
+            @PathVariable Long academyId,
+
+            @Parameter(description = "학생 엑셀 파일 (.xlsx)")
+            @RequestPart("file") MultipartFile file,
+
+            @Parameter(description = "기본 클래스 ID (엑셀에 class 컬럼 없을 때)")
+            @RequestParam(value = "classId", required = false) Long classId,
+
+            @Parameter(description = "AI 헤더 매핑 사용")
+            @RequestParam(value = "useAi", defaultValue = "true") boolean useAi,
+
+            @Parameter(description = "검증만 수행 (DB 저장 안함)")
+            @RequestParam(value = "dryRun", defaultValue = "false") boolean dryRun
+    ) {
+        return academyStudentUploadService.upload(academyId, file, classId, useAi, dryRun);
+    }
+
 }

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/model/request/AcademyStudentCreateRequest.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/model/request/AcademyStudentCreateRequest.java
@@ -1,8 +1,12 @@
 package com.qoocca.teachers.api.academy.model.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class AcademyStudentCreateRequest {
 

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/model/response/AcademyStudentUploadError.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/model/response/AcademyStudentUploadError.java
@@ -1,0 +1,11 @@
+package com.qoocca.teachers.api.academy.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AcademyStudentUploadError {
+    private int rowNumber;
+    private String message;
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/model/response/AcademyStudentUploadResponse.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/model/response/AcademyStudentUploadResponse.java
@@ -1,0 +1,17 @@
+package com.qoocca.teachers.api.academy.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+public class AcademyStudentUploadResponse {
+    private int totalRows;
+    private int successCount;
+    private int failureCount;
+    private Map<String, String> headerMapping;
+    private List<AcademyStudentUploadError> errors;
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/AcademyStudentUploadService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/AcademyStudentUploadService.java
@@ -1,0 +1,282 @@
+package com.qoocca.teachers.api.academy.service;
+
+import com.qoocca.teachers.api.academy.model.request.AcademyStudentCreateRequest;
+import com.qoocca.teachers.api.academy.model.response.AcademyStudentResponse;
+import com.qoocca.teachers.api.academy.model.response.AcademyStudentUploadError;
+import com.qoocca.teachers.api.academy.model.response.AcademyStudentUploadResponse;
+import com.qoocca.teachers.api.classInfo.model.request.ClassStudentRequest;
+import com.qoocca.teachers.api.classInfo.service.ClassInfoStudentService;
+import com.qoocca.teachers.db.classInfo.entity.ClassInfoEntity;
+import com.qoocca.teachers.db.classInfo.repository.ClassInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AcademyStudentUploadService {
+
+    private static final int MAX_ROWS = 500;
+
+    private static final Set<String> STUDENT_NAME_KEYS = Set.of(
+            "studentname", "name", "student", "학생", "학생이름", "이름", "성함", "학생명"
+    );
+    private static final Set<String> STUDENT_PHONE_KEYS = Set.of(
+            "studentphone", "phone", "mobile", "cell", "tel", "전화", "연락처", "휴대폰", "핸드폰"
+    );
+    private static final Set<String> CLASS_NAME_KEYS = Set.of(
+            "classname", "class", "course", "반", "수업", "클래스", "강좌"
+    );
+
+    private final AcademyStudentService academyStudentService;
+    private final ClassInfoStudentService classInfoStudentService;
+    private final ClassInfoRepository classInfoRepository;
+    private final OpenAiHeaderMappingClient openAiHeaderMappingClient;
+
+    public AcademyStudentUploadResponse upload(
+            Long academyId,
+            MultipartFile file,
+            Long classId,
+            boolean useAi,
+            boolean dryRun
+    ) {
+        List<AcademyStudentUploadError> errors = new ArrayList<>();
+        Map<String, String> headerMapping = new HashMap<>();
+
+        if (file == null || file.isEmpty()) {
+            errors.add(new AcademyStudentUploadError(0, "Empty file"));
+            return buildResponse(0, 0, 0, headerMapping, errors);
+        }
+
+        DataFormatter formatter = new DataFormatter();
+
+        try (InputStream inputStream = file.getInputStream();
+             Workbook workbook = WorkbookFactory.create(inputStream)) {
+
+            Sheet sheet = workbook.getSheetAt(0);
+            Row headerRow = sheet.getRow(0);
+            if (headerRow == null) {
+                errors.add(new AcademyStudentUploadError(0, "Missing header row"));
+                return buildResponse(0, 0, 0, headerMapping, errors);
+            }
+
+            List<String> headers = readHeaders(headerRow, formatter);
+            Map<String, Integer> fieldIndex = mapHeaders(headers, useAi, classId != null);
+            headerMapping.putAll(buildHeaderMapping(headers, fieldIndex));
+
+            if (!fieldIndex.containsKey("studentName") || !fieldIndex.containsKey("studentPhone")) {
+                errors.add(new AcademyStudentUploadError(0, "Required columns not found"));
+                return buildResponse(0, 0, 0, headerMapping, errors);
+            }
+            if (classId == null && !fieldIndex.containsKey("className")) {
+                errors.add(new AcademyStudentUploadError(0, "Class column not found"));
+                return buildResponse(0, 0, 0, headerMapping, errors);
+            }
+
+            int totalRows = 0;
+            int successCount = 0;
+
+            for (int i = 1; i <= sheet.getLastRowNum(); i++) {
+                Row row = sheet.getRow(i);
+                if (row == null || isRowEmpty(row, formatter)) {
+                    continue;
+                }
+                totalRows++;
+                if (totalRows > MAX_ROWS) {
+                    errors.add(new AcademyStudentUploadError(i + 1, "Row limit exceeded"));
+                    break;
+                }
+
+                String studentName = getCellValue(row, fieldIndex.get("studentName"), formatter);
+                String studentPhone = getCellValue(row, fieldIndex.get("studentPhone"), formatter);
+                String className = classId == null
+                        ? getCellValue(row, fieldIndex.get("className"), formatter)
+                        : null;
+
+                if (isBlank(studentName) || isBlank(studentPhone)) {
+                    errors.add(new AcademyStudentUploadError(i + 1, "Missing required student data"));
+                    continue;
+                }
+                if (classId == null && isBlank(className)) {
+                    errors.add(new AcademyStudentUploadError(i + 1, "Missing class name"));
+                    continue;
+                }
+
+                if (dryRun) {
+                    if (classId == null && resolveClassId(academyId, className).isEmpty()) {
+                        errors.add(new AcademyStudentUploadError(i + 1, "Class not found: " + className));
+                        continue;
+                    }
+                    successCount++;
+                    continue;
+                }
+
+                try {
+                    AcademyStudentResponse student = academyStudentService.registerStudent(
+                            academyId,
+                            new AcademyStudentCreateRequest(studentName, studentPhone)
+                    );
+
+                    Long targetClassId = classId != null
+                            ? classId
+                            : resolveClassId(academyId, className).orElse(null);
+
+                    if (targetClassId == null) {
+                        errors.add(new AcademyStudentUploadError(i + 1, "Class not found: " + className));
+                        continue;
+                    }
+
+                    classInfoStudentService.register(
+                            targetClassId,
+                            new ClassStudentRequest(student.getStudentId())
+                    );
+                    successCount++;
+                } catch (Exception e) {
+                    errors.add(new AcademyStudentUploadError(i + 1, e.getMessage()));
+                }
+            }
+
+            return buildResponse(totalRows, successCount, totalRows - successCount, headerMapping, errors);
+        } catch (Exception e) {
+            errors.add(new AcademyStudentUploadError(0, "Failed to parse Excel file"));
+            return buildResponse(0, 0, 0, headerMapping, errors);
+        }
+    }
+
+    private List<String> readHeaders(Row headerRow, DataFormatter formatter) {
+        List<String> headers = new ArrayList<>();
+        short last = headerRow.getLastCellNum();
+        for (int i = 0; i < last; i++) {
+            headers.add(formatter.formatCellValue(headerRow.getCell(i)).trim());
+        }
+        return headers;
+    }
+
+    private Map<String, String> buildHeaderMapping(List<String> headers, Map<String, Integer> fieldIndex) {
+        Map<String, String> mapping = new HashMap<>();
+        fieldIndex.forEach((field, index) -> {
+            if (index >= 0 && index < headers.size()) {
+                mapping.put(field, headers.get(index));
+            }
+        });
+        return mapping;
+    }
+
+    private Map<String, Integer> mapHeaders(List<String> headers, boolean useAi, boolean classIdProvided) {
+        Map<String, Integer> fieldIndex = new HashMap<>();
+
+        for (int i = 0; i < headers.size(); i++) {
+            String normalized = normalize(headers.get(i));
+            if (!fieldIndex.containsKey("studentName") && STUDENT_NAME_KEYS.contains(normalized)) {
+                fieldIndex.put("studentName", i);
+            } else if (!fieldIndex.containsKey("studentPhone") && STUDENT_PHONE_KEYS.contains(normalized)) {
+                fieldIndex.put("studentPhone", i);
+            } else if (!fieldIndex.containsKey("className") && CLASS_NAME_KEYS.contains(normalized)) {
+                fieldIndex.put("className", i);
+            }
+        }
+
+        boolean missingRequired = !fieldIndex.containsKey("studentName")
+                || !fieldIndex.containsKey("studentPhone")
+                || (!classIdProvided && !fieldIndex.containsKey("className"));
+
+        if (useAi && missingRequired) {
+            Map<String, String> aiMapping = openAiHeaderMappingClient.mapHeaders(headers);
+            aiMapping.forEach((field, headerName) -> {
+                if (!fieldIndex.containsKey(field)) {
+                    Integer idx = findHeaderIndex(headers, headerName);
+                    if (idx != null) {
+                        fieldIndex.put(field, idx);
+                    }
+                }
+            });
+        }
+
+        return fieldIndex;
+    }
+
+    private Integer findHeaderIndex(List<String> headers, String target) {
+        if (target == null || target.isBlank()) {
+            return null;
+        }
+        for (int i = 0; i < headers.size(); i++) {
+            if (headers.get(i).equalsIgnoreCase(target)) {
+                return i;
+            }
+        }
+        String normalizedTarget = normalize(target);
+        for (int i = 0; i < headers.size(); i++) {
+            if (normalize(headers.get(i)).equals(normalizedTarget)) {
+                return i;
+            }
+        }
+        return null;
+    }
+
+    private Optional<Long> resolveClassId(Long academyId, String className) {
+        if (isBlank(className)) {
+            return Optional.empty();
+        }
+        return classInfoRepository.findByAcademy_IdAndClassName(academyId, className.trim())
+                .map(ClassInfoEntity::getClassId);
+    }
+
+    private boolean isRowEmpty(Row row, DataFormatter formatter) {
+        short last = row.getLastCellNum();
+        for (int i = 0; i < last; i++) {
+            if (!formatter.formatCellValue(row.getCell(i)).isBlank()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String getCellValue(Row row, Integer index, DataFormatter formatter) {
+        if (index == null || index < 0) {
+            return "";
+        }
+        return formatter.formatCellValue(row.getCell(index)).trim();
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.trim().toLowerCase().replaceAll("[\\s_\\-]", "");
+    }
+
+    private AcademyStudentUploadResponse buildResponse(
+            int totalRows,
+            int successCount,
+            int failureCount,
+            Map<String, String> headerMapping,
+            List<AcademyStudentUploadError> errors
+    ) {
+        return AcademyStudentUploadResponse.builder()
+                .totalRows(totalRows)
+                .successCount(successCount)
+                .failureCount(failureCount)
+                .headerMapping(headerMapping)
+                .errors(errors)
+                .build();
+    }
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/OpenAiHeaderMappingClient.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/OpenAiHeaderMappingClient.java
@@ -1,0 +1,109 @@
+package com.qoocca.teachers.api.academy.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qoocca.teachers.api.global.config.OpenAiProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OpenAiHeaderMappingClient {
+
+    private final OpenAiProperties properties;
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public Map<String, String> mapHeaders(List<String> headers) {
+        Map<String, String> mapping = new HashMap<>();
+        if (properties.getApiKey() == null || properties.getApiKey().isBlank()) {
+            return mapping;
+        }
+
+        String prompt = buildPrompt(headers);
+        Map<String, Object> request = buildRequest(prompt);
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setBearerAuth(properties.getApiKey());
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request, httpHeaders);
+
+        try {
+            String response = restTemplate.postForObject(
+                    properties.getBaseUrl() + "/chat/completions",
+                    entity,
+                    String.class
+            );
+            return parseMapping(response);
+        } catch (RestClientException e) {
+            return mapping;
+        }
+    }
+
+    private Map<String, Object> buildRequest(String prompt) {
+        Map<String, Object> request = new HashMap<>();
+        request.put("model", properties.getModel());
+        request.put("temperature", 0);
+
+        List<Map<String, String>> messages = List.of(
+                Map.of("role", "system", "content",
+                        "You map spreadsheet headers to canonical fields. " +
+                                "Return JSON only."),
+                Map.of("role", "user", "content", prompt)
+        );
+        request.put("messages", messages);
+        return request;
+    }
+
+    private String buildPrompt(List<String> headers) {
+        return "Canonical fields: studentName, studentPhone, className.\n" +
+                "Input headers: " + headers + "\n" +
+                "Return JSON:\n" +
+                "{\n" +
+                "  \"studentName\": {\"header\": \"...\", \"confidence\": 0.0-1.0},\n" +
+                "  \"studentPhone\": {\"header\": \"...\", \"confidence\": 0.0-1.0},\n" +
+                "  \"className\": {\"header\": \"...\", \"confidence\": 0.0-1.0}\n" +
+                "}";
+    }
+
+    private Map<String, String> parseMapping(String responseBody) {
+        Map<String, String> mapping = new HashMap<>();
+        if (responseBody == null || responseBody.isBlank()) {
+            return mapping;
+        }
+
+        try {
+            JsonNode root = objectMapper.readTree(responseBody);
+            JsonNode content = root.at("/choices/0/message/content");
+            if (content.isMissingNode() || content.asText().isBlank()) {
+                return mapping;
+            }
+            JsonNode payload = objectMapper.readTree(content.asText());
+            mapping.put("studentName", getHeaderName(payload, "studentName"));
+            mapping.put("studentPhone", getHeaderName(payload, "studentPhone"));
+            mapping.put("className", getHeaderName(payload, "className"));
+            return mapping;
+        } catch (Exception e) {
+            return mapping;
+        }
+    }
+
+    private String getHeaderName(JsonNode payload, String field) {
+        JsonNode node = payload.path(field).path("header");
+        if (node.isMissingNode()) {
+            return null;
+        }
+        String value = node.asText();
+        return value == null || value.isBlank() ? null : value;
+    }
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/model/request/ClassStudentRequest.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/model/request/ClassStudentRequest.java
@@ -1,8 +1,12 @@
 package com.qoocca.teachers.api.classInfo.model.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class ClassStudentRequest {
 

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/global/config/OpenAiConfig.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/global/config/OpenAiConfig.java
@@ -1,0 +1,9 @@
+package com.qoocca.teachers.api.global.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(OpenAiProperties.class)
+public class OpenAiConfig {
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/global/config/OpenAiProperties.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/global/config/OpenAiProperties.java
@@ -1,0 +1,14 @@
+package com.qoocca.teachers.api.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "openai")
+public class OpenAiProperties {
+    private String apiKey;
+    private String baseUrl = "https://api.openai.com/v1";
+    private String model = "gpt-4o-mini";
+}

--- a/qoocca-api/src/main/resources/application.yml
+++ b/qoocca-api/src/main/resources/application.yml
@@ -41,6 +41,9 @@ naver:
   client-secret: ${NAVER_CLIENT_SECRET}
   redirect-uri: ${NAVER_REDIRECT_URI}
 
+openai:
+  api-key: ${OPENAI_API_KEY}
+
 file:
   upload:
     path: D:/qoocca-be/nginx/images/

--- a/qoocca-db/src/main/java/com/qoocca/teachers/db/classInfo/repository/ClassInfoRepository.java
+++ b/qoocca-db/src/main/java/com/qoocca/teachers/db/classInfo/repository/ClassInfoRepository.java
@@ -9,10 +9,13 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface ClassInfoRepository extends JpaRepository<ClassInfoEntity, Long> {
 
     List<ClassInfoEntity> findByAcademy_Id(Long academyId);
+
+    Optional<ClassInfoEntity> findByAcademy_IdAndClassName(Long academyId, String className);
 
     // Age, Subject 정보를 한 번에 조회
     @Query("SELECT c FROM ClassInfoEntity c " +


### PR DESCRIPTION
구현한 로직
1) 업로드 엔드포인트

  - 파일과 옵션을 받을 새로운 API를 추가했습니다.
  - 위치: qoocca-api/src/main/java/com/qoocca/teachers/api/academy/controller/
    AcademyStudentController.java
  - 경로: POST /api/academy/{academyId}/student/upload
  - 파라미터
      - file (multipart)
      - classId (옵션): 엑셀에 클래스 컬럼이 없으면 고정 클래스 지정
      - useAi (기본 true): 헤더 매핑에 AI 사용 여부
      - dryRun (기본 false): 저장 없이 검증만 수행

  컨트롤러에서는 바로 서비스로 위임:

  - academyStudentUploadService.upload(academyId, file, classId, useAi, dryRun)

  ———

  2) 엑셀 파싱 + DB 저장 로직 (핵심)

  - 위치: qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/
    AcademyStudentUploadService.java
  - Apache POI 사용 (의존성 추가: org.apache.poi:poi-ooxml:5.2.5)

  처리 흐름:

  1. 파일/헤더 유효성 검사
      - 파일이 비었으면 즉시 에러 반환.
      - 첫 번째 시트의 1행을 헤더로 읽음.
  2. 헤더 목록 추출
      - DataFormatter로 셀을 문자열로 통일.
      - headers = ["성함","연락처","반"...]
  3. 헤더 매핑
      - 먼저 규칙 기반 매핑 (AI 없이도 동작)
          - normalize: 공백/언더스코어/하이픈 제거 + 소문자화
          - 사전 키워드로 매핑
              - studentName: 학생, 학생이름, 성함, name 등
              - studentPhone: 연락처, 휴대폰, phone 등
              - className: 반, 수업, class 등
      - 필요한 컬럼이 누락되면 useAi=true일 때만 OpenAI로 보완 매핑
      - 최종 매핑은 fieldIndex (필드 → 컬럼 인덱스)
  4. 필수 컬럼 체크
      - studentName/studentPhone 없으면 종료
      - classId가 없고 className도 못 찾으면 종료
  5. 데이터 행 처리
      - 2행부터 끝까지 반복
      - 빈 줄은 스킵
      - 최대 500행 제한 (MAX_ROWS)
      - 각 행에서:
          - studentName, studentPhone, className 추출
          - 필수값 누락 시 에러 기록
          - dryRun=true면 DB 저장 없이 검증만
              - className이 있는 경우 클래스 존재 여부만 검사
  6. 실제 저장 로직
      - academyStudentService.registerStudent() 재사용
        → 학생 테이블 저장 + academy-student 연결 생성
      - 클래스 배정:
          - classId가 있으면 그대로 사용
          - 없으면 className으로 ClassInfoRepository.findByAcademy_IdAndClassName() 조회
      - classInfoStudentService.register() 호출로 클래스 배정
      - 예외 발생 시 행별 에러로 기록하고 계속 진행

  ———

  3) AI 헤더 매핑 로직

  - 위치: qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/
    OpenAiHeaderMappingClient.java

  동작 방식:

  1. OpenAI API Key가 없으면 빈 결과 반환 (AI 비활성)
  2. headers만 보내서 헤더 매핑 JSON을 요청
  3. 기대 응답 형태:

  {
    "studentName": {"header": "성함", "confidence": 0.91},
    "studentPhone": {"header": "연락처", "confidence": 0.88},
    "className": {"header": "반", "confidence": 0.77}
  }

  4. 응답 JSON에서 header 값만 추출해서 매핑 시도
  5. 매핑 실패 시 기본 규칙 결과만 사용

  주의점:

  - 학생 이름/전화 같은 실제 데이터는 AI에 보내지 않음
  - 헤더 문자열만 보냄 (PII 최소화)

  ———

  4) 설정 바인딩

  - .env에 OPENAI_API_KEY= 추가
  - qoocca-api/src/main/resources/application.yml에:

  openai:
    api-key: ${OPENAI_API_KEY}

  ———

  결과적으로 흐름은 이렇게 됩니다

  엑셀 업로드
    → 헤더 읽기
      → 규칙 기반 매핑
        → 부족하면 AI 매핑 보완
    → 행 데이터 파싱
      → 학생 등록(기존 registerStudent 재사용)
      → 클래스 배정(register 호출)
    → 결과 리포트 반환

 
 Swagger에서 이렇게 테스트하면 됩니다.
  1. POST /api/academy/{academyId}/student/upload
  2. academyId 입력
  3. file에 엑셀 선택
  4. 필요하면 classId 입력(엑셀에 클래스가 없을 때)
  5. useAi=true, dryRun=true로 먼저 실행해 매핑/에러 확인
  6. 문제 없으면 dryRun=false로 다시 실행해 실제 저장

  참고: OPENAI_API_KEY가 비어있으면 AI 매핑 없이 사전 규칙만 사용됩니다. 
.env 파일에  OPENAI_API_KEY= 키값입력 하고 테스트해주세요!!



확인해주실 점은 엑셀 데이터 20개 기준으로 테스트하였고, 한번에 한 엑셀파일만 업로드가능하게 처리해두었는데 더 큰데이터가 들어올때 서버에 부하가 없을지, 한 엑셀파일만 업로드 가능하게 하는 로직을 여러 엑셀파일 업로드가능하게 수정할지 확인부탁드립니다.


  