### PR TITLE
fix/14 학생 엔티티 번호 유니크 및 openAi 일부 수정

### DIFF
--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/AcademyStudentUploadService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/AcademyStudentUploadService.java
@@ -76,7 +76,7 @@ public class AcademyStudentUploadService {
             }
 
             List<String> headers = readHeaders(headerRow, formatter);
-            Map<String, Integer> fieldIndex = mapHeaders(headers, useAi, classId != null);
+            Map<String, Integer> fieldIndex = mapHeaders(academyId, headers, useAi, classId != null);
             headerMapping.putAll(buildHeaderMapping(headers, fieldIndex));
 
             if (!fieldIndex.containsKey("studentName") || !fieldIndex.containsKey("studentPhone")) {
@@ -177,7 +177,7 @@ public class AcademyStudentUploadService {
         return mapping;
     }
 
-    private Map<String, Integer> mapHeaders(List<String> headers, boolean useAi, boolean classIdProvided) {
+    private Map<String, Integer> mapHeaders(Long academyId, List<String> headers, boolean useAi, boolean classIdProvided) {
         Map<String, Integer> fieldIndex = new HashMap<>();
 
         for (int i = 0; i < headers.size(); i++) {
@@ -196,7 +196,7 @@ public class AcademyStudentUploadService {
                 || (!classIdProvided && !fieldIndex.containsKey("className"));
 
         if (useAi && missingRequired) {
-            Map<String, String> aiMapping = openAiHeaderMappingClient.mapHeaders(headers);
+            Map<String, String> aiMapping = openAiHeaderMappingClient.mapHeaders(academyId, headers);
             aiMapping.forEach((field, headerName) -> {
                 if (!fieldIndex.containsKey(field)) {
                     Integer idx = findHeaderIndex(headers, headerName);

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/OpenAiHeaderMappingClient.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/OpenAiHeaderMappingClient.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.qoocca.teachers.api.global.config.OpenAiProperties;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -11,26 +13,99 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OpenAiHeaderMappingClient {
 
     private final OpenAiProperties properties;
     private final ObjectMapper objectMapper;
+    private final StringRedisTemplate redis;
     private final RestTemplate restTemplate = new RestTemplate();
 
-    public Map<String, String> mapHeaders(List<String> headers) {
-        Map<String, String> mapping = new HashMap<>();
+    private static final Duration HEADER_CACHE_TTL = Duration.ofHours(24);
+    private static final Duration COOLDOWN_TTL = Duration.ofSeconds(10);
+
+    private static final String CACHE_PREFIX = "ai:headerMap:v1:";
+    private static final String COOLDOWN_PREFIX = "ai:headerMap:cooldown:v1:";
+
+    public Map<String, String> mapHeaders(Long academyId, List<String> headers) {
         if (properties.getApiKey() == null || properties.getApiKey().isBlank()) {
-            return mapping;
+            log.warn("OpenAI API key not configured");
+            return Map.of();
+        }
+        if (headers == null || headers.isEmpty()) return Map.of();
+
+        // 1) 캐시 조회
+        String cacheKey = CACHE_PREFIX + sha256(String.join("|", headers));
+        Map<String, String> cached = readCache(cacheKey);
+        if (cached != null) {
+            log.debug("Header mapping cache hit (model={}): {}", properties.getModel(), cached);
+            return cached;
         }
 
-        String prompt = buildPrompt(headers);
-        Map<String, Object> request = buildRequest(prompt);
+        // 2) 쿨다운 (폭주 방지)
+        if (academyId != null) {
+            String coolKey = COOLDOWN_PREFIX + academyId;
+            Boolean ok = redis.opsForValue().setIfAbsent(coolKey, "1", COOLDOWN_TTL);
+            if (Boolean.FALSE.equals(ok)) {
+                log.warn("AI header mapping skipped by cooldown (academyId={})", academyId);
+                return Map.of(); // 여기서 룰 기반 fallback으로 이어도 됨
+            }
+        }
+
+        // 3) OpenAI 호출
+        Map<String, String> mapping;
+        try {
+            mapping = callOpenAI(headers);
+        } catch (Exception e) {
+            log.error("OpenAI header mapping failed", e);
+            return Map.of();
+        }
+
+        // 4) 캐시 저장
+        if (!mapping.isEmpty()) writeCache(cacheKey, mapping);
+
+        return mapping;
+    }
+
+    private Map<String, String> readCache(String key) {
+        try {
+            String json = redis.opsForValue().get(key);
+            if (json == null || json.isBlank()) return null;
+            return objectMapper.readValue(json, new com.fasterxml.jackson.core.type.TypeReference<>() {});
+        } catch (Exception e) {
+            log.warn("Failed to read cache key={}", key, e);
+            return null;
+        }
+    }
+
+    private void writeCache(String key, Map<String, String> mapping) {
+        try {
+            String json = objectMapper.writeValueAsString(mapping);
+            redis.opsForValue().set(key, json, HEADER_CACHE_TTL);
+        } catch (Exception e) {
+            log.warn("Failed to write cache key={}", key, e);
+        }
+    }
+
+    private Map<String, String> callOpenAI(List<String> headers) {
+        Map<String, Object> request = new HashMap<>();
+        request.put("model", properties.getModel());
+        request.put("temperature", 0);
+        request.put("max_tokens", 120);
+
+        String prompt = "Map headers to fields (studentName, studentPhone, className). " +
+                "Return JSON object with keys studentName, studentPhone, className and string values.\n" +
+                "Headers: " + headers;
+
+        request.put("messages", List.of(Map.of("role", "user", "content", prompt)));
 
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setBearerAuth(properties.getApiKey());
@@ -38,72 +113,45 @@ public class OpenAiHeaderMappingClient {
 
         HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request, httpHeaders);
 
-        try {
-            String response = restTemplate.postForObject(
-                    properties.getBaseUrl() + "/chat/completions",
-                    entity,
-                    String.class
-            );
-            return parseMapping(response);
-        } catch (RestClientException e) {
-            return mapping;
-        }
-    }
+        String url = properties.getBaseUrl() + "/chat/completions";
+        String response = restTemplate.postForObject(url, entity, String.class);
 
-    private Map<String, Object> buildRequest(String prompt) {
-        Map<String, Object> request = new HashMap<>();
-        request.put("model", properties.getModel());
-        request.put("temperature", 0);
-
-        List<Map<String, String>> messages = List.of(
-                Map.of("role", "system", "content",
-                        "You map spreadsheet headers to canonical fields. " +
-                                "Return JSON only."),
-                Map.of("role", "user", "content", prompt)
-        );
-        request.put("messages", messages);
-        return request;
-    }
-
-    private String buildPrompt(List<String> headers) {
-        return "Canonical fields: studentName, studentPhone, className.\n" +
-                "Input headers: " + headers + "\n" +
-                "Return JSON:\n" +
-                "{\n" +
-                "  \"studentName\": {\"header\": \"...\", \"confidence\": 0.0-1.0},\n" +
-                "  \"studentPhone\": {\"header\": \"...\", \"confidence\": 0.0-1.0},\n" +
-                "  \"className\": {\"header\": \"...\", \"confidence\": 0.0-1.0}\n" +
-                "}";
+        return parseMapping(response);
     }
 
     private Map<String, String> parseMapping(String responseBody) {
-        Map<String, String> mapping = new HashMap<>();
-        if (responseBody == null || responseBody.isBlank()) {
-            return mapping;
-        }
-
+        if (responseBody == null || responseBody.isBlank()) return Map.of();
         try {
             JsonNode root = objectMapper.readTree(responseBody);
             JsonNode content = root.at("/choices/0/message/content");
-            if (content.isMissingNode() || content.asText().isBlank()) {
-                return mapping;
-            }
+            if (content.isMissingNode() || content.asText().isBlank()) return Map.of();
+
             JsonNode payload = objectMapper.readTree(content.asText());
-            mapping.put("studentName", getHeaderName(payload, "studentName"));
-            mapping.put("studentPhone", getHeaderName(payload, "studentPhone"));
-            mapping.put("className", getHeaderName(payload, "className"));
-            return mapping;
+
+            Map<String, String> out = new HashMap<>();
+            put(out, "studentName", payload.path("studentName").asText(null));
+            put(out, "studentPhone", payload.path("studentPhone").asText(null));
+            put(out, "className", payload.path("className").asText(null));
+            return out;
         } catch (Exception e) {
-            return mapping;
+            log.error("Failed to parse OpenAI response", e);
+            return Map.of();
         }
     }
 
-    private String getHeaderName(JsonNode payload, String field) {
-        JsonNode node = payload.path(field).path("header");
-        if (node.isMissingNode()) {
-            return null;
+    private void put(Map<String, String> map, String key, String value) {
+        if (value != null && !value.isBlank()) map.put(key, value);
+    }
+
+    private String sha256(String input) {
+        try {
+            var md = java.security.MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(input.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hash) sb.append(String.format("%02x", b));
+            return sb.toString();
+        } catch (Exception e) {
+            return Integer.toHexString(Objects.hashCode(input));
         }
-        String value = node.asText();
-        return value == null || value.isBlank() ? null : value;
     }
 }

--- a/qoocca-auth/src/main/java/com/qoocca/teachers/auth/config/RedisConfig.java
+++ b/qoocca-auth/src/main/java/com/qoocca/teachers/auth/config/RedisConfig.java
@@ -9,6 +9,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
@@ -36,18 +37,23 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(lettuceConnectionFactory());
+        redisTemplate.setConnectionFactory(connectionFactory);
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
-
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashValueSerializer(new StringRedisSerializer());
 
         return redisTemplate;
     }
+
 
     // 캐싱 기능을 활용하기 위한 CacheManager 설정
     @Bean

--- a/qoocca-db/src/main/java/com/qoocca/teachers/db/student/entity/StudentEntity.java
+++ b/qoocca-db/src/main/java/com/qoocca/teachers/db/student/entity/StudentEntity.java
@@ -36,7 +36,7 @@ public class StudentEntity {
     @Column(name = "student_name")
     private String studentName;
 
-    @Column(name = "student_phone")
+    @Column(name = "student_phone", unique = true)
     private String studentPhone;
 
 


### PR DESCRIPTION
학생 테이블 번호에 Unique 제약 조건 추가

**엑셀 업로드 트랜잭션 안정성 개선**
업로드 전체를 하나의 트랜잭션으로 묶는 구조에서 발생하던 문제를 식별
중복 데이터로 인한 DB 예외 발생 시 Hibernate 세션 오염으로 500 오류가 발생하던 이슈를 정리
행 단위 처리 실패가 전체 업로드 실패로 이어질 수 있음을 확인
(후속 작업으로 행 단위 트랜잭션 분리 또는 중복 데이터 스킵/조회 로직 적용 가능)

**AI 기반 엑셀 헤더 매핑 기능 고도화**
엑셀 헤더가 표준적이지 않은 경우를 대비해 OpenAI 기반 헤더 매핑 기능 유지
단, 다음 조건에서만 AI 호출하도록 제한 (useAi = true)
룰 기반 헤더 매핑 실패 시 (missingRequired = true)
➡ 정상적인 엑셀 업로드에서는 AI 호출이 발생하지 않도록 최적화

**Redis 기반 캐시 및 쿨다운(Lag) 적용**
OpenAI 헤더 매핑 결과를 Redis에 캐시하여 동일한 헤더 조합에 대해 재사용
Redis TTL 적용
헤더 매핑 캐시: 24시간
academyId 기준 쿨다운 키: 10초
이를 통해:
- 중복 OpenAI 호출 방지
- 비용 절감
- 업로드 연속 호출 시 안정성 확보

**Redis 적용 확인 방식 정리**
AI 헤더 매핑은 룰 기반 매핑이 실패한 경우에만 실행되므로,
정상적인 엑셀 업로드에서는 Redis 키가 생성되지 않는 것이 정상 동작임

Redis 키 예시:
ai:headerMap:v1:* (헤더 매핑 캐시)
ai:headerMap:cooldown:v1:{academyId} (쿨다운)