### PR TITLE
fix/15 add new errorCode

### DIFF
--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/AcademyService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/AcademyService.java
@@ -121,7 +121,7 @@ public class AcademyService {
                 req.getCertificateFile().transferTo(new File(academyFolderPath + certFileName));
                 academy.setCertificate(IMAGE_BASE_URL + academy.getId() + "/" + certFileName);
             } catch (IOException e) {
-                throw new RuntimeException("사업자 등록증 저장 실패", e);
+                throw new CustomException(ErrorCode.ACADEMY_CERTIFICATE_SAVE_FAILED);
             }
         }
 
@@ -135,7 +135,7 @@ public class AcademyService {
                     file.transferTo(new File(academyFolderPath + filename));
                     finalImageUrls.add(IMAGE_BASE_URL + academy.getId() + "/" + filename);
                 } catch (IOException e) {
-                    throw new RuntimeException("이미지 파일 저장 실패", e);
+                    throw new CustomException(ErrorCode.ACADEMY_IMAGE_SAVE_FAILED);
                 }
             }
         }
@@ -276,7 +276,7 @@ public class AcademyService {
                             .build();
                     oldImages.add(newImage);
                 } catch (IOException e) {
-                    throw new RuntimeException("새 이미지 저장 실패", e);
+                    throw new CustomException(ErrorCode.ACADEMY_IMAGE_SAVE_FAILED);
                 }
             }
         }
@@ -291,7 +291,7 @@ public class AcademyService {
                 fileToDelete.delete();
             }
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new CustomException(ErrorCode.ACADEMY_IMAGE_DELETE_FAILED);
         }
     }
 

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/AcademyStudentService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/AcademyStudentService.java
@@ -3,6 +3,8 @@ package com.qoocca.teachers.api.academy.service;
 import com.qoocca.teachers.api.academy.model.request.AcademyStudentCreateRequest;
 import com.qoocca.teachers.api.academy.model.request.AcademyStudentModifyRequest;
 import com.qoocca.teachers.api.academy.model.response.AcademyStudentResponse;
+import com.qoocca.teachers.common.global.exception.CustomException;
+import com.qoocca.teachers.common.global.exception.ErrorCode;
 import com.qoocca.teachers.db.academy.entity.AcademyEntity;
 import com.qoocca.teachers.db.academy.entity.AcademyStudentEntity;
 import com.qoocca.teachers.db.academy.repository.AcademyRepository;
@@ -27,7 +29,7 @@ public class AcademyStudentService {
     public AcademyStudentResponse registerStudent(Long academyId, AcademyStudentCreateRequest request) {
 
         AcademyEntity academy = academyRepository.findById(academyId)
-                .orElseThrow(() -> new IllegalArgumentException("학원 없음"));
+                .orElseThrow(() -> new CustomException(ErrorCode.ACADEMY_NOT_FOUND));
 
         // 기존 학생 있는지 확인, 없으면 새로 생성
         StudentEntity student = studentRepository
@@ -59,7 +61,7 @@ public class AcademyStudentService {
 
         AcademyStudentEntity relation = academyStudentRepository
                 .findByAcademy_IdAndStudent_StudentId(academyId, studentId)
-                .orElseThrow(() -> new IllegalArgumentException("학생이 학원에 등록되어 있지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.ACADEMY_STUDENT_RELATION_NOT_FOUND));
 
         StudentEntity student = relation.getStudent();
 
@@ -81,7 +83,7 @@ public class AcademyStudentService {
 
         AcademyStudentEntity relation = academyStudentRepository
                 .findByAcademy_IdAndStudent_StudentId(academyId, studentId)
-                .orElseThrow(() -> new IllegalArgumentException("관계 없음"));
+                .orElseThrow(() -> new CustomException(ErrorCode.ACADEMY_STUDENT_RELATION_NOT_FOUND));
 
         academyStudentRepository.delete(relation);
     }

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/service/ClassInfoStudentService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/service/ClassInfoStudentService.java
@@ -36,7 +36,7 @@ public class ClassInfoStudentService {
 
         // 이미 등록되어 있는지 체크
         if (repository.existsByClassInfo_ClassIdAndStudent_StudentId(classId, request.getStudentId())) {
-            throw new IllegalStateException("이미 등록된 학생입니다.");
+            throw new CustomException(ErrorCode.STUDENT_ALREADY_ENROLLED);
         }
 
         // 클래스 존재 확인
@@ -75,15 +75,15 @@ public class ClassInfoStudentService {
         // 기존 반 수강 정보 조회
         ClassInfoStudentEntity current = classInfoStudentRepository
                 .findByClassInfo_ClassIdAndStudent_StudentId(classId, studentId)
-                .orElseThrow(() -> new IllegalArgumentException("기존 반 수강 정보가 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.ENROLLMENT_NOT_FOUND));
 
         // 이동할 반 존재 확인
         ClassInfoEntity targetClass = classInfoRepository.findById(targetClassId)
-                .orElseThrow(() -> new IllegalArgumentException("대상 반이 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.CLASS_NOT_FOUND));
 
         // 중복 등록 방지
         if (classInfoStudentRepository.existsByClassInfo_ClassIdAndStudent_StudentId(targetClassId, studentId)) {
-            throw new IllegalStateException("이미 대상 반에 등록된 학생입니다.");
+            throw new CustomException(ErrorCode.STUDENT_ALREADY_ENROLLED);
         }
 
         StudentEntity student = current.getStudent();

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/student/service/StudentParentService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/student/service/StudentParentService.java
@@ -9,6 +9,8 @@ import com.qoocca.teachers.db.student.entity.StudentEntity;
 import com.qoocca.teachers.db.student.entity.StudentParentEntity;
 import com.qoocca.teachers.db.student.repository.StudentParentRepository;
 import com.qoocca.teachers.db.student.repository.StudentRepository;
+import com.qoocca.teachers.common.global.exception.CustomException;
+import com.qoocca.teachers.common.global.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,7 +38,7 @@ public class StudentParentService {
     public ParentResponse addParent(Long studentId, ParentCreateRequest request) {
 
         StudentEntity student = studentRepository.findById(studentId)
-                .orElseThrow(() -> new IllegalArgumentException("학생을 찾을 수 없습니다. id=" + studentId));
+                .orElseThrow(() -> new CustomException(ErrorCode.STUDENT_NOT_FOUND));
 
         String cardNum = request.getCardNum();
         boolean hasCard = (cardNum != null && !cardNum.isBlank());
@@ -68,7 +70,7 @@ public class StudentParentService {
 
         StudentParentEntity sp = studentParentRepository
                 .findByStudent_StudentIdAndParent_ParentId(studentId, parentId)
-                .orElseThrow(() -> new IllegalArgumentException("학생-부모 관계를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.STUDENT_PARENT_RELATION_NOT_FOUND));
 
         ParentEntity parent = sp.getParent();
 

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/student/service/StudentService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/student/service/StudentService.java
@@ -3,6 +3,8 @@ package com.qoocca.teachers.api.student.service;
 import com.qoocca.teachers.db.student.entity.StudentEntity;
 import com.qoocca.teachers.api.student.model.StudentCreateRequest;
 import com.qoocca.teachers.api.student.model.StudentResponse;
+import com.qoocca.teachers.common.global.exception.CustomException;
+import com.qoocca.teachers.common.global.exception.ErrorCode;
 import com.qoocca.teachers.db.student.repository.StudentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,7 +32,7 @@ public class StudentService {
     @Transactional(readOnly = true)
     public StudentResponse get(Long studentId) {
         StudentEntity student = studentRepository.findById(studentId)
-                .orElseThrow(() -> new IllegalArgumentException("학생 없음"));
+                .orElseThrow(() -> new CustomException(ErrorCode.STUDENT_NOT_FOUND));
 
         return StudentResponse.from(student);
     }
@@ -38,7 +40,7 @@ public class StudentService {
     public StudentResponse update(Long studentId, StudentCreateRequest request) {
 
         StudentEntity student = studentRepository.findById(studentId)
-                .orElseThrow(() -> new IllegalArgumentException("학생 없음"));
+                .orElseThrow(() -> new CustomException(ErrorCode.STUDENT_NOT_FOUND));
 
         if (request.getStudentName() != null) {
             student.setStudentName(request.getStudentName());
@@ -54,7 +56,7 @@ public class StudentService {
 
     public void delete(Long studentId) {
         StudentEntity student = studentRepository.findById(studentId)
-                .orElseThrow(() -> new IllegalArgumentException("학생 없음"));
+                .orElseThrow(() -> new CustomException(ErrorCode.STUDENT_NOT_FOUND));
 
         studentRepository.delete(student); // 또는 soft delete 컬럼 추가 가능
     }

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/user/service/SmsService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/user/service/SmsService.java
@@ -1,6 +1,8 @@
 package com.qoocca.teachers.api.user.service;
 
 import com.qoocca.teachers.common.redis.RedisDao;
+import com.qoocca.teachers.common.global.exception.CustomException;
+import com.qoocca.teachers.common.global.exception.ErrorCode;
 import com.qoocca.teachers.db.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,7 +22,7 @@ public class SmsService {
         String cleanPhone = phone.replaceAll("[^0-9]", "");
 
         if (cleanPhone.length() != 11) {
-            throw new RuntimeException("휴대폰 번호는 11자리여야 합니다.");
+            throw new CustomException(ErrorCode.SMS_INVALID_PHONE);
         }
 
         String verificationCode = String.valueOf(ThreadLocalRandom.current().nextInt(100000, 1000000));
@@ -42,14 +44,14 @@ public class SmsService {
             result.put("isExistingUser", isExistingUser);
             return result;
         } else {
-            throw new RuntimeException("인증번호가 일치하지 않거나 만료되었습니다.");
+            throw new CustomException(ErrorCode.SMS_CODE_INVALID);
         }
     }
 
     public void checkIsVerified(String phone) {
         String verified = (String) redisDao.getValues("SMS_VERIFIED:" + phone);
         if (!"true".equals(verified)) {
-            throw new RuntimeException("휴대폰 인증이 완료되지 않았습니다.");
+            throw new CustomException(ErrorCode.SMS_NOT_VERIFIED);
         }
     }
 

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/user/service/UserService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/user/service/UserService.java
@@ -54,7 +54,7 @@ public class UserService {
         UserEntity userEntity = userRepository.findByPhoneNumber(req.getPhone())
                 .map(existingUser -> {
                     if (existingUser.getPassword() != null) {
-                        throw new RuntimeException("이미 사용 중인 전화번호 입니다.");
+                        throw new CustomException(ErrorCode.PHONE_ALREADY_IN_USE);
                     }
                     existingUser.setEmail(req.getEmail());
                     existingUser.setUserName(req.getUsername());
@@ -148,7 +148,7 @@ public class UserService {
                 !agreements.isService() ||
                 !agreements.isPrivacy() ||
                 !agreements.isThirdParty()) {
-            throw new RuntimeException("필수 약관 동의가 누락되었습니다.");
+            throw new CustomException(ErrorCode.REQUIRED_AGREEMENTS_MISSING);
         }
     }
 

--- a/qoocca-auth/src/main/java/com/qoocca/teachers/auth/config/RedisTest.java
+++ b/qoocca-auth/src/main/java/com/qoocca/teachers/auth/config/RedisTest.java
@@ -1,0 +1,26 @@
+package com.qoocca.teachers.auth.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Component
+public class RedisTest {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @PostConstruct
+    public void testRedis() {
+        try {
+            // 테스트용 값 설정
+            redisTemplate.opsForValue().set("ping", "pong");
+            String value = (String) redisTemplate.opsForValue().get("ping");
+            System.out.println("Redis 연결 성공: " + value);
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println("Redis 연결 실패");
+        }
+    }
+}

--- a/qoocca-common/src/main/java/com/qoocca/teachers/common/global/exception/ErrorCode.java
+++ b/qoocca-common/src/main/java/com/qoocca/teachers/common/global/exception/ErrorCode.java
@@ -8,47 +8,49 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
     USER_NOT_FOUND(404, "U001", "사용자를 찾을 수 없습니다."),
     INVALID_PASSWORD(400, "U002", "비밀번호가 일치하지 않습니다."),
+    PHONE_ALREADY_IN_USE(400, "U003", "이미 사용 중인 전화번호입니다."),
+    REQUIRED_AGREEMENTS_MISSING(400, "U004", "필수 약관에 동의하지 않았습니다."),
     SOCIAL_PROVIDER_NOT_FOUND(400, "S001", "지원하지 않는 소셜 로그인 제공자입니다."),
     INVALID_SOCIAL_CODE(400, "S002", "소셜 로그인 인증 코드가 유효하지 않습니다."),
+    SMS_INVALID_PHONE(400, "SM001", "유효하지 않은 전화번호입니다."),
+    SMS_CODE_INVALID(400, "SM002", "인증 코드가 유효하지 않거나 만료되었습니다."),
+    SMS_NOT_VERIFIED(400, "SM003", "전화번호 인증이 완료되지 않았습니다."),
     AGE_NOT_FOUND(404, "AC002", "존재하지 않는 연령대 ID입니다."),
     SUBJECT_NOT_FOUND(404, "AC003", "존재하지 않는 과목 ID입니다."),
 
     INVALID_TOKEN(401, "A001", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(401, "A002", "만료된 토큰입니다."),
     LOGOUT_TOKEN(401, "A003", "이미 로그아웃된 토큰입니다."),
-    TOKEN_MISMATCH(401, "A004", "서버의 토큰 정보와 일치하지 않습니다."),
+    TOKEN_MISMATCH(401, "A004", "서버 토큰 정보가 일치하지 않습니다."),
 
-    ACADEMY_NOT_APPROVED(403, "AC004", "학원 승인이 완료되지 않아 접근할 수 없습니다."),
+    ACADEMY_NOT_APPROVED(403, "AC004", "학원 승인 완료 전에는 접근할 수 없습니다."),
     ACADEMY_NOT_FOUND(404, "AC001", "학원 정보를 찾을 수 없습니다."),
+    ACADEMY_CERTIFICATE_SAVE_FAILED(500, "AC005", "학원 인증서 저장에 실패했습니다."),
+    ACADEMY_IMAGE_SAVE_FAILED(500, "AC006", "학원 이미지 저장에 실패했습니다."),
+    ACADEMY_IMAGE_DELETE_FAILED(500, "AC007", "학원 이미지 삭제에 실패했습니다."),
+    ACADEMY_STUDENT_RELATION_NOT_FOUND(404, "AC008", "학원-학생 관계를 찾을 수 없습니다."),
     NO_AUTHORITY(403, "G001", "권한이 없습니다."),
 
-    /**
-     * 출결 관련
-     */
-    ATTENDANCE_ALREADY_EXISTS (400, "AT001", "이미 해당 수업에 대한 오늘자 출결 기록이 존재합니다."),
-    ATTENDANCE_NOT_FOUND (404, "AT002", "출결 기록을 찾을 수 없습니다."),
-    CLASS_NOT_FOUND_FOR_TIME (400, "AT003", "현재 시간에 수강하는 수업이 없습니다."),
+    // 출결 관련
+    ATTENDANCE_ALREADY_EXISTS(400, "AT001", "이미 해당 수업에 오늘 출결 기록이 존재합니다."),
+    ATTENDANCE_NOT_FOUND(404, "AT002", "출결 기록을 찾을 수 없습니다."),
+    CLASS_NOT_FOUND_FOR_TIME(400, "AT003", "현재 시간에 해당하는 수업이 없습니다."),
 
-    /**
-     * 클래스 및 수강생 관련
-     */
-    STUDENT_NOT_FOUND (404, "ST001", "학생 정보를 찾을 수 없습니다."),
-    CLASS_NOT_FOUND (404, "C001", "클래스 정보를 찾을 수 없습니다."),
-    STUDENT_ALREADY_ENROLLED (400, "C002", "이미 해당 클래스에 등록된 학생입니다."),
-    ENROLLMENT_NOT_FOUND (404, "C003", "수강 정보를 찾을 수 없습니다."),
+    // 클래스/수강 관련
+    STUDENT_NOT_FOUND(404, "ST001", "학생 정보를 찾을 수 없습니다."),
+    STUDENT_PARENT_RELATION_NOT_FOUND(404, "ST002", "학생-부모 관계를 찾을 수 없습니다."),
+    CLASS_NOT_FOUND(404, "C001", "클래스 정보를 찾을 수 없습니다."),
+    STUDENT_ALREADY_ENROLLED(400, "C002", "이미 해당 클래스에 등록된 학생입니다."),
+    ENROLLMENT_NOT_FOUND(404, "C003", "수강 정보를 찾을 수 없습니다."),
 
-    /**
-     * 수납 관련
-     */
-    DUPLICATE_RECEIPT_IN_MONTH (400, "R001", "해당 월에 이미 수납 기록이 존재합니다."),
-    RECEIPT_NOT_FOUND (404, "R002", "수납 기록(영수증)을 찾을 수 없습니다."),
-    RECEIPT_ACCESS_DENIED (403, "R003", "본인의 수납 기록만 접근할 수 있습니다."),
+    // 수납 관련
+    DUPLICATE_RECEIPT_IN_MONTH(400, "R001", "해당 월에 이미 수납 기록이 존재합니다."),
+    RECEIPT_NOT_FOUND(404, "R002", "수납 기록(영수증)을 찾을 수 없습니다."),
+    RECEIPT_ACCESS_DENIED(403, "R003", "본인의 수납 기록만 조회할 수 있습니다."),
 
-    /**
-     * 시스템 공통
-     */
-    INVALID_INPUT_VALUE (400, "G002", "입력값이 올바르지 않습니다."),
-    INTERNAL_SERVER_ERROR (500, "G003", "서버 내부 오류가 발생했습니다.");
+    // 공통
+    INVALID_INPUT_VALUE(400, "G002", "입력값이 올바르지 않습니다."),
+    INTERNAL_SERVER_ERROR(500, "G003", "서버 내부 오류가 발생했습니다.");
 
     private final int status;
     private final String code;


### PR DESCRIPTION
각 서비스의 예외 처리를 CustomException + ErrorCode 기반으로 통일하고,
기존 RuntimeException/IllegalArgumentException 등을 의미에 맞는 ErrorCode로 교체했습니다.

---

## 주요 변경 사항

### 1. ErrorCode 신규 추가
- 사용자 / SMS 인증 / 학원 이미지 처리 / 학원-학생 관계 / 학생-부모 관계 관련 코드 추가

📁 `qoocca-common/.../ErrorCode.java`

---

### 2. Academy 서비스 예외 표준화
- 파일 저장/삭제 실패 → CustomException + ErrorCode 사용

📁 `AcademyService.java`

---

### 3. 학원-학생 관계 예외 통일
- 등록/수정/삭제 시 관계 없음, 학원 없음 케이스 통일

📁 `AcademyStudentService.java`

---

### 4. 클래스 학생 등록/이동 예외 통일

📁 `ClassInfoStudentService.java`

---

### 5. User / SMS 서비스 예외 표준화

📁 `UserService.java`  
📁 `SmsService.java`

---

### 6. 학생 / 학생-부모 관계 없음 케이스 통일

📁 `StudentService.java`  
📁 `StudentParentService.java`

---

## 추가된 ErrorCode 요약

**User**
- PHONE_ALREADY_IN_USE  
- REQUIRED_AGREEMENTS_MISSING  

**SMS**
- SMS_INVALID_PHONE  
- SMS_CODE_INVALID  
- SMS_NOT_VERIFIED  

**Academy**
- ACADEMY_CERTIFICATE_SAVE_FAILED  
- ACADEMY_IMAGE_SAVE_FAILED  
- ACADEMY_IMAGE_DELETE_FAILED  
- ACADEMY_STUDENT_RELATION_NOT_FOUND  

**Student**
- STUDENT_PARENT_RELATION_NOT_FOUND  

---

## 테스트 가이드

1. 기존 주요 플로우 정상 동작 확인
2. 아래 케이스에서 ErrorCode 반환 확인

- SMS 인증 안 된 상태로 회원가입
- 중복 전화번호 회원가입
- 학원 이미지 업로드 실패
- 학생-학원 관계 없는 수정/삭제
- 학생-부모 관계 없는 수정
