### PR TITLE
feature/27 FCM 기반 학부모 푸시 알림 + Receipt(수납) 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,11 @@ qoocca-api/src/main/resources/application.yml
 src/main/resources/data.sql
 nginx
 Dockerfile
+
+appliction.properties
+service-account.json
+google-services.json
+key.properties
+*.jks
+*.keystore
+*.log

--- a/qoocca-api/build.gradle
+++ b/qoocca-api/build.gradle
@@ -10,4 +10,6 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
 }

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/global/config/FirebaseConfig.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/global/config/FirebaseConfig.java
@@ -1,0 +1,37 @@
+package com.qoocca.teachers.api.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void init() {
+        try {
+            // ClassPathResource를 사용해서 stream으로 읽기
+            ClassPathResource resource = new ClassPathResource("service-account.json");
+            InputStream serviceAccount = resource.getInputStream();
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) { // 이미 초기화되어 있으면 중복 방지
+                FirebaseApp.initializeApp(options);
+                System.out.println("✅ Firebase initialized successfully");
+            }
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.err.println("❌ Firebase initialization failed");
+        }
+    }
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/global/controller/FcmController.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/global/controller/FcmController.java
@@ -1,0 +1,21 @@
+package com.qoocca.teachers.api.global.controller;
+
+import com.qoocca.teachers.api.global.service.FcmPushService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/fcm")
+public class FcmController {
+
+    private final FcmPushService fcmService;
+
+    public FcmController(FcmPushService fcmService) {
+        this.fcmService = fcmService;
+    }
+
+    @PostMapping("/register")
+    public String registerToken(@RequestParam Long parentId, @RequestParam String fcmToken) {
+        fcmService.registerToken(parentId, fcmToken);
+        return "FCM token registered";
+    }
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/global/service/FcmPushService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/global/service/FcmPushService.java
@@ -1,0 +1,53 @@
+package com.qoocca.teachers.api.global.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.qoocca.teachers.db.fcm.FirebaseTokenEntity;
+import com.qoocca.teachers.db.fcm.FirebaseTokenRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class FcmPushService {
+
+    private final FirebaseTokenRepository tokenRepository;
+
+    public FcmPushService(FirebaseTokenRepository tokenRepository) {
+        this.tokenRepository = tokenRepository;
+    }
+
+    // 1截뤴깵 ?대씪?댁뼵?몄뿉??諛쏆? ?좏겙 ???媛깆떊
+    public void registerToken(Long parentId, String token) {
+        Optional<FirebaseTokenEntity> existing = tokenRepository.findByParentId(parentId);
+        FirebaseTokenEntity entity = existing.orElseGet(FirebaseTokenEntity::new);
+        entity.setParentId(parentId);
+        entity.setFcmToken(token);
+        tokenRepository.save(entity);
+    }
+
+    // 2截뤴깵 ?좎??먭쾶 ?몄떆 蹂대궡湲?
+    public void sendPushToUser(Long parentId, Long receiptId, String title, String body) {
+        tokenRepository.findByParentId(parentId).ifPresent(token -> {
+            sendPush(token.getFcmToken(), receiptId, title, body);
+        });
+    }
+
+    // 3截뤴깵 ?ㅼ젣 FCM ?꾩넚
+    private void sendPush(String token, Long receiptId, String title, String body) {
+        Message message = Message.builder()
+                .setToken(token)
+                .putData("receiptId", receiptId != null ? receiptId.toString() : "")
+                .putData("title", title != null ? title : "")
+                .putData("body", body != null ? body : "")
+                .build();
+
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            System.out.println("??Sent message: " + response);
+        } catch (FirebaseMessagingException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/parent/auth/controller/ParentAuthController.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/parent/auth/controller/ParentAuthController.java
@@ -1,0 +1,25 @@
+package com.qoocca.teachers.api.parent.auth.controller;
+
+import com.qoocca.teachers.api.parent.auth.dto.ParentLoginRequest;
+import com.qoocca.teachers.api.parent.auth.dto.ParentLoginResponse;
+import com.qoocca.teachers.api.parent.auth.service.ParentAuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/parent/auth")
+@RequiredArgsConstructor
+public class ParentAuthController {
+
+    private final ParentAuthService parentAuthService;
+
+    @PostMapping("/login")
+    public ResponseEntity<ParentLoginResponse> login(@Valid @RequestBody ParentLoginRequest request) {
+        return ResponseEntity.ok(parentAuthService.login(request));
+    }
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/parent/auth/dto/ParentLoginRequest.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/parent/auth/dto/ParentLoginRequest.java
@@ -1,0 +1,17 @@
+package com.qoocca.teachers.api.parent.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ParentLoginRequest {
+
+    @NotBlank
+    private String parentPhone;
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/parent/auth/dto/ParentLoginResponse.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/parent/auth/dto/ParentLoginResponse.java
@@ -1,0 +1,26 @@
+package com.qoocca.teachers.api.parent.auth.dto;
+
+import com.qoocca.teachers.db.parent.entity.ParentEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ParentLoginResponse {
+
+    private Long parentId;
+    private String parentName;
+    private String parentPhone;
+
+    public static ParentLoginResponse from(ParentEntity parent) {
+        return ParentLoginResponse.builder()
+                .parentId(parent.getParentId())
+                .parentName(parent.getParentName())
+                .parentPhone(parent.getParentPhone())
+                .build();
+    }
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/parent/auth/service/ParentAuthService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/parent/auth/service/ParentAuthService.java
@@ -1,0 +1,30 @@
+package com.qoocca.teachers.api.parent.auth.service;
+
+import com.qoocca.teachers.api.parent.auth.dto.ParentLoginRequest;
+import com.qoocca.teachers.api.parent.auth.dto.ParentLoginResponse;
+import com.qoocca.teachers.common.global.exception.CustomException;
+import com.qoocca.teachers.common.global.exception.ErrorCode;
+import com.qoocca.teachers.db.parent.entity.ParentEntity;
+import com.qoocca.teachers.db.parent.repository.ParentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ParentAuthService {
+
+    private final ParentRepository parentRepository;
+
+    @Transactional(readOnly = true)
+    public ParentLoginResponse login(ParentLoginRequest request) {
+        if (request.getParentPhone() == null || request.getParentPhone().isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        ParentEntity parent = parentRepository.findByParentPhone(request.getParentPhone())
+                .orElseThrow(() -> new CustomException(ErrorCode.PARENT_NOT_FOUND));
+
+        return ParentLoginResponse.from(parent);
+    }
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/payment/PaymentController.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/payment/PaymentController.java
@@ -1,0 +1,21 @@
+package com.qoocca.teachers.api.payment;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/payment")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    public PaymentController(PaymentService paymentService) {
+        this.paymentService = paymentService;
+    }
+
+    @PostMapping("/complete")
+    public String completePayment(@RequestParam Long receiptId,
+                                  @RequestParam Long parentId) {
+        paymentService.completePayment(receiptId, parentId);
+        return "Payment completed";
+    }
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/payment/PaymentService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/payment/PaymentService.java
@@ -1,0 +1,37 @@
+package com.qoocca.teachers.api.payment;
+
+import com.qoocca.teachers.common.global.exception.CustomException;
+import com.qoocca.teachers.common.global.exception.ErrorCode;
+import com.qoocca.teachers.db.receipt.entity.ReceiptEntity;
+import com.qoocca.teachers.db.receipt.repository.ReceiptRepository;
+import com.qoocca.teachers.db.student.repository.StudentParentRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PaymentService {
+
+    private final ReceiptRepository receiptRepository;
+    private final StudentParentRepository studentParentRepository;
+
+    public PaymentService(ReceiptRepository receiptRepository,
+                          StudentParentRepository studentParentRepository) {
+        this.receiptRepository = receiptRepository;
+        this.studentParentRepository = studentParentRepository;
+    }
+
+    @Transactional
+    public void completePayment(Long receiptId, Long parentId) {
+        ReceiptEntity receipt = receiptRepository.findById(receiptId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECEIPT_NOT_FOUND));
+
+        boolean isParent = studentParentRepository
+                .findByStudent_StudentIdAndParent_ParentId(receipt.getStudent().getStudentId(), parentId)
+                .isPresent();
+        if (!isParent) {
+            throw new CustomException(ErrorCode.STUDENT_PARENT_RELATION_NOT_FOUND);
+        }
+
+        receipt.setReceiptStatus(ReceiptEntity.ReceiptStatus.PAID);
+    }
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/receipt/controller/ReceiptController.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/receipt/controller/ReceiptController.java
@@ -2,7 +2,6 @@ package com.qoocca.teachers.api.receipt.controller;
 
 import com.qoocca.teachers.api.receipt.model.ReceiptCreateRequest;
 import com.qoocca.teachers.api.receipt.model.ReceiptUpdateRequest;
-import com.qoocca.teachers.api.receipt.model.*;
 import com.qoocca.teachers.api.receipt.model.response.ReceiptCreateResponse;
 import com.qoocca.teachers.api.receipt.model.response.ReceiptResponse;
 import com.qoocca.teachers.api.receipt.model.response.ReceiptUpdateResponse;
@@ -11,49 +10,57 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@Tag(name = "Student Receipt API", description = "학생 개인별 수납 내역 등록, 수정 및 상세 조회 API")
+@Tag(name = "Student Receipt API", description = "Student receipt create/update/query API")
 @RestController
 @RequestMapping("/api/student/{studentId}/receipt")
 @RequiredArgsConstructor
 public class ReceiptController {
 
+
     private final ReceiptService receiptService;
 
-    @Operation(summary = "수납 기록 생성", description = "특정 학생의 수업에 대한 수납(결제 요청/완료) 기록을 생성합니다. 한 달에 한 번만 생성이 가능하도록 제한됩니다.")
+    @Operation(summary = "Create receipt", description = "Create a receipt record for a student.")
     @PostMapping
     public ReceiptCreateResponse createReceipt(
-            @Parameter(description = "학생 ID", example = "1") @PathVariable Long studentId,
+            @Parameter(description = "Student ID", example = "1") @PathVariable Long studentId,
             @RequestBody ReceiptCreateRequest request
     ) {
         return receiptService.createReceipt(studentId, request);
     }
 
-    @Operation(summary = "학생 전체 수납 이력 조회", description = "특정 학생이 지금까지 결제했거나 청구된 모든 수납 내역을 조회합니다.")
+    @Operation(summary = "List receipts", description = "List all receipts for a student.")
     @GetMapping
     public List<ReceiptResponse> getAllReceipts(
-            @Parameter(description = "학생 ID", example = "1") @PathVariable Long studentId) {
+            @Parameter(description = "Student ID", example = "1") @PathVariable Long studentId) {
         return receiptService.getReceiptsByStudent(studentId);
     }
 
-    @Operation(summary = "학생 월별 수납 내역 조회", description = "연도와 월을 지정하여 해당 기간에 발생한 학생의 수납 내역을 조회합니다.")
+    @Operation(summary = "Monthly receipts", description = "List receipts for a student by year/month.")
     @GetMapping("/month")
     public List<ReceiptResponse> getMonthlyReceipts(
-            @Parameter(description = "학생 ID", example = "1") @PathVariable Long studentId,
-            @Parameter(description = "조회 연도", example = "2026") @RequestParam int year,
-            @Parameter(description = "조회 월", example = "1") @RequestParam int month
+            @Parameter(description = "Student ID", example = "1") @PathVariable Long studentId,
+            @Parameter(description = "Year", example = "2026") @RequestParam int year,
+            @Parameter(description = "Month", example = "1") @RequestParam int month
     ) {
         return receiptService.getReceiptsByStudentAndMonth(studentId, year, month);
     }
 
-    @Operation(summary = "수납 상태 수정", description = "발행된 영수증의 상태(결제 완료, 수납 취소 등)를 업데이트합니다.")
+    @Operation(summary = "Update receipt status", description = "Update receipt status for a student.")
     @PutMapping("/{receiptId}")
     public ReceiptUpdateResponse updateReceiptStatus(
-            @Parameter(description = "학생 ID", example = "1") @PathVariable Long studentId,
-            @Parameter(description = "영수증(수납) ID", example = "100") @PathVariable Long receiptId,
+            @Parameter(description = "Student ID", example = "1") @PathVariable Long studentId,
+            @Parameter(description = "Receipt ID", example = "100") @PathVariable Long receiptId,
             @RequestBody ReceiptUpdateRequest request
     ) {
         return receiptService.updateReceiptStatus(studentId, receiptId, request);

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/receipt/controller/ReceiptPaymentController.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/receipt/controller/ReceiptPaymentController.java
@@ -1,0 +1,31 @@
+package com.qoocca.teachers.api.receipt.controller;
+
+import com.qoocca.teachers.api.receipt.model.response.ReceiptUpdateResponse;
+import com.qoocca.teachers.api.receipt.service.ReceiptService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/receipt")
+@RequiredArgsConstructor
+public class ReceiptPaymentController {
+
+    private final ReceiptService receiptService;
+
+    @PostMapping("/{receiptId}/pay")
+    public ResponseEntity<ReceiptUpdateResponse> payReceipt(@PathVariable Long receiptId,
+                                                            @RequestParam Long parentId) {
+        return ResponseEntity.ok(receiptService.payReceipt(receiptId, parentId));
+    }
+
+    @PostMapping("/{receiptId}/cancel")
+    public ResponseEntity<ReceiptUpdateResponse> cancelReceipt(@PathVariable Long receiptId,
+                                                               @RequestParam Long parentId) {
+        return ResponseEntity.ok(receiptService.cancelReceipt(receiptId, parentId));
+    }
+}

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/receipt/model/ReceiptCreateRequest.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/receipt/model/ReceiptCreateRequest.java
@@ -1,6 +1,5 @@
 package com.qoocca.teachers.api.receipt.model;
 
-import com.qoocca.teachers.db.receipt.entity.ReceiptEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,5 +15,4 @@ public class ReceiptCreateRequest {
     private Long amount;
     private Long classId;
     private LocalDateTime receiptDate;
-    private ReceiptEntity.ReceiptStatus receiptStatus;
 }

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/receipt/service/ReceiptService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/receipt/service/ReceiptService.java
@@ -3,6 +3,7 @@ package com.qoocca.teachers.api.receipt.service;
 import com.qoocca.teachers.api.receipt.model.ReceiptCreateRequest;
 import com.qoocca.teachers.api.receipt.model.ReceiptUpdateRequest;
 import com.qoocca.teachers.api.receipt.model.response.*;
+import com.qoocca.teachers.api.global.service.FcmPushService;
 import com.qoocca.teachers.db.classInfo.entity.ClassInfoEntity;
 import com.qoocca.teachers.db.classInfo.entity.ClassInfoStudentEntity;
 import com.qoocca.teachers.db.classInfo.entity.StudentStatus;
@@ -38,6 +39,7 @@ public class ReceiptService {
     private final ClassInfoRepository classInfoRepository;
     private final ClassInfoStudentRepository classInfoStudentRepository;
     private final StudentParentRepository studentParentRepository;
+    private final FcmPushService fcmPushService;
 
     /* =========================
      * POST: 수납 생성 (한 달에 1회 제한 로직 추가)
@@ -64,9 +66,20 @@ public class ReceiptService {
         }
 
         ReceiptEntity receipt = ReceiptEntity.createReceipt(
-                student, classInfo, request.getAmount(), request.getReceiptDate(), request.getReceiptStatus());
+                student, classInfo, request.getAmount(), request.getReceiptDate(), ReceiptEntity.ReceiptStatus.ISSUED);
 
-        return ReceiptCreateResponse.fromEntity(receiptRepository.save(receipt));
+        ReceiptEntity saved = receiptRepository.save(receipt);
+
+        List<StudentParentEntity> parents = studentParentRepository.findByStudent_StudentId(studentId);
+        String title = "Payment request";
+        String body = "Class: " + classInfo.getClassName() + ", amount: " + request.getAmount();
+        for (StudentParentEntity sp : parents) {
+            if (sp.getParent() != null && sp.getParent().getParentId() != null) {
+                fcmPushService.sendPushToUser(sp.getParent().getParentId(), saved.getReceiptId(), title, body);
+            }
+        }
+
+        return ReceiptCreateResponse.fromEntity(saved);
     }
 
     /* =========================
@@ -110,6 +123,18 @@ public class ReceiptService {
             receipt.setReceiptStatus(request.getReceiptStatus());
         }
 
+        return ReceiptUpdateResponse.fromEntity(receipt);
+    }
+
+    public ReceiptUpdateResponse payReceipt(Long receiptId, Long parentId) {
+        ReceiptEntity receipt = getReceiptForParentAction(receiptId, parentId);
+        receipt.setReceiptStatus(ReceiptEntity.ReceiptStatus.PAID);
+        return ReceiptUpdateResponse.fromEntity(receipt);
+    }
+
+    public ReceiptUpdateResponse cancelReceipt(Long receiptId, Long parentId) {
+        ReceiptEntity receipt = getReceiptForParentAction(receiptId, parentId);
+        receipt.setReceiptStatus(ReceiptEntity.ReceiptStatus.CANCELLED);
         return ReceiptUpdateResponse.fromEntity(receipt);
     }
 
@@ -169,12 +194,6 @@ public class ReceiptService {
                     .totalAmount(cls.getPrice() * enrollments.size())
                     .build();
         }).collect(Collectors.toList());
-    }
-
-    private boolean isAlreadyProcessedInMonth(Long studentId, Long classId, LocalDateTime date) {
-        YearMonth ym = YearMonth.from(date != null ? date : LocalDateTime.now());
-        return receiptRepository.existsByStudent_StudentIdAndClassInfo_ClassIdAndReceiptDateBetween(
-                studentId, classId, ym.atDay(1).atStartOfDay(), ym.atEndOfMonth().atTime(23, 59, 59));
     }
 
     private ReceiptDataContainer prepareReceiptData(Long academyId, int year, int month) {
@@ -237,4 +256,29 @@ public class ReceiptService {
         }
         return hasIssued ? ReceiptEntity.ReceiptStatus.ISSUED : ReceiptEntity.ReceiptStatus.PAID;
     }
+
+    private ReceiptEntity getReceiptForParentAction(Long receiptId, Long parentId) {
+        ReceiptEntity receipt = receiptRepository.findById(receiptId)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECEIPT_NOT_FOUND));
+
+        boolean isParent = studentParentRepository
+                .findByStudent_StudentIdAndParent_ParentId(receipt.getStudent().getStudentId(), parentId)
+                .isPresent();
+        if (!isParent) {
+            throw new CustomException(ErrorCode.STUDENT_PARENT_RELATION_NOT_FOUND);
+        }
+
+        if (receipt.getReceiptStatus() != ReceiptEntity.ReceiptStatus.ISSUED) {
+            throw new CustomException(ErrorCode.INVALID_RECEIPT_STATUS);
+        }
+
+        return receipt;
+    }
+
+    private boolean isAlreadyProcessedInMonth(Long studentId, Long classId, LocalDateTime date) {
+        YearMonth ym = YearMonth.from(date != null ? date : LocalDateTime.now());
+        return receiptRepository.existsByStudent_StudentIdAndClassInfo_ClassIdAndReceiptDateBetween(
+                studentId, classId, ym.atDay(1).atStartOfDay(), ym.atEndOfMonth().atTime(23, 59, 59));
+    }
 }
+

--- a/qoocca-auth/src/main/java/com/qoocca/teachers/auth/config/SecurityConfig.java
+++ b/qoocca-auth/src/main/java/com/qoocca/teachers/auth/config/SecurityConfig.java
@@ -41,18 +41,36 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+
+                        // Swagger
                         .requestMatchers(
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html"
                         ).permitAll()
-                        .requestMatchers("/api/auth/**", "/api/ages", "/api/subjects").permitAll()
-                        .requestMatchers("/api/auth/**", "/oauth2/**").permitAll()
+
+                        // Auth & public APIs
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/api/parent/auth/login",
+                                "/oauth2/**",
+                                "/api/ages",
+                                "/api/subjects",
+
+                                // ✅ FCM 토큰 등록 API 허용
+                                "/api/fcm/register",
+                                "/api/receipt/**"
+                        ).permitAll()
+
+                        // Admin only
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/class/**").hasRole("ADMIN")
-                        .requestMatchers(HttpMethod.PUT, "/api/class/**").hasAnyRole("USER", "ADMIN")
 
+                        // User or Admin
+                        .requestMatchers(HttpMethod.PUT, "/api/class/**").hasAnyRole("USER", "ADMIN")
                         .requestMatchers("/api/academy/**").hasAnyRole("USER", "ADMIN")
+
+                        // Everything else
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
@@ -71,7 +89,6 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowedOrigins(allowedOrigins);
-
         config.addAllowedMethod("*");
         config.addAllowedHeader("*");
         config.setAllowCredentials(true);

--- a/qoocca-common/src/main/java/com/qoocca/teachers/common/global/exception/ErrorCode.java
+++ b/qoocca-common/src/main/java/com/qoocca/teachers/common/global/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
      */
     STUDENT_NOT_FOUND(404, "ST001", "학생 정보를 찾을 수 없습니다."),
     STUDENT_PARENT_RELATION_NOT_FOUND(404, "ST002", "학생-부모 관계를 찾을 수 없습니다."),
+    PARENT_NOT_FOUND(404, "ST003", "부모 정보를 찾을 수 없습니다."),
     CLASS_NOT_FOUND(404, "C001", "클래스 정보를 찾을 수 없습니다."),
     STUDENT_ALREADY_ENROLLED(400, "C002", "이미 해당 클래스에 등록된 학생입니다."),
     ENROLLMENT_NOT_FOUND(404, "C003", "수강 정보를 찾을 수 없습니다."),
@@ -54,6 +55,7 @@ public enum ErrorCode {
     RECEIPT_NOT_FOUND (404, "R002", "수납 기록(영수증)을 찾을 수 없습니다."),
     RECEIPT_ACCESS_DENIED (403, "R003", "본인의 수납 기록만 접근할 수 있습니다."),
     PAYMENT_METHOD_NOT_FOUND(400, "R004", "등록된 결제 수단이 없습니다."),
+    INVALID_RECEIPT_STATUS(400, "R005", "수납 상태 변경이 허용되지 않습니다."),
 
     /**
      * 시스템 공통

--- a/qoocca-db/build.gradle
+++ b/qoocca-db/build.gradle
@@ -10,4 +10,6 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'io.github.cdimascio:dotenv-java:3.0.0'
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
+
 }

--- a/qoocca-db/src/main/java/com/qoocca/teachers/db/fcm/FirebaseTokenEntity.java
+++ b/qoocca-db/src/main/java/com/qoocca/teachers/db/fcm/FirebaseTokenEntity.java
@@ -1,0 +1,27 @@
+package com.qoocca.teachers.db.fcm;
+
+import jakarta.persistence.*;
+
+@Entity
+public class FirebaseTokenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long parentId;
+
+    @Column(nullable = false)
+    private String fcmToken;
+
+    // getters, setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Long getParentId() { return parentId; }
+    public void setParentId(Long parentId) { this.parentId = parentId; }
+
+    public String getFcmToken() { return fcmToken; }
+    public void setFcmToken(String fcmToken) { this.fcmToken = fcmToken; }
+}

--- a/qoocca-db/src/main/java/com/qoocca/teachers/db/fcm/FirebaseTokenRepository.java
+++ b/qoocca-db/src/main/java/com/qoocca/teachers/db/fcm/FirebaseTokenRepository.java
@@ -1,0 +1,9 @@
+package com.qoocca.teachers.db.fcm;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FirebaseTokenRepository extends JpaRepository<FirebaseTokenEntity, Long> {
+    Optional<FirebaseTokenEntity> findByParentId(Long parentId);
+}

--- a/qoocca-db/src/main/java/com/qoocca/teachers/db/parent/repository/ParentRepository.java
+++ b/qoocca-db/src/main/java/com/qoocca/teachers/db/parent/repository/ParentRepository.java
@@ -5,8 +5,11 @@ import com.qoocca.teachers.db.parent.entity.ParentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ParentRepository
         extends JpaRepository<ParentEntity, Long> {
 
+    Optional<ParentEntity> findByParentPhone(String parentPhone);
 }

--- a/qoocca-db/src/main/java/com/qoocca/teachers/db/student/entity/StudentParentEntity.java
+++ b/qoocca-db/src/main/java/com/qoocca/teachers/db/student/entity/StudentParentEntity.java
@@ -29,6 +29,7 @@ public class StudentParentEntity {
     @Column(name = "student_parent_id")
     private Long studentParentId;
 
+
     /* =========================
      * 연관관계 (FK)
      * ========================= */

--- a/src/main/java/com/example/qoocca_be/academy/dto/AcademyStudentCreateRequest.java
+++ b/src/main/java/com/example/qoocca_be/academy/dto/AcademyStudentCreateRequest.java
@@ -1,0 +1,14 @@
+package com.example.qoocca_be.academy.dto;
+
+import com.example.qoocca_be.student.entity.StudentEntity;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class AcademyStudentCreateRequest {
+
+    @NotBlank
+    private String studentName;
+
+
+}

--- a/src/main/java/com/example/qoocca_be/academy/service/AcademyStudentService.java
+++ b/src/main/java/com/example/qoocca_be/academy/service/AcademyStudentService.java
@@ -1,0 +1,62 @@
+package com.example.qoocca_be.academy.service;
+
+import com.example.qoocca_be.academy.dto.AcademyStudentCreateRequest;
+import com.example.qoocca_be.academy.dto.AcademyStudentResponse;
+import com.example.qoocca_be.academy.entity.AcademyEntity;
+import com.example.qoocca_be.academy.entity.AcademyStudentEntity;
+import com.example.qoocca_be.academy.repository.AcademyRepository;
+import com.example.qoocca_be.academy.repository.AcademyStudentRepository;
+import com.example.qoocca_be.student.entity.StudentEntity;
+import com.example.qoocca_be.student.repository.StudentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AcademyStudentService {
+
+    private final AcademyRepository academyRepository;
+    private final StudentRepository studentRepository;
+    private final AcademyStudentRepository academyStudentRepository;
+
+    public AcademyStudentResponse registerStudent(Long academyId, AcademyStudentCreateRequest request) {
+
+        AcademyEntity academy = academyRepository.findById(academyId)
+                .orElseThrow(() -> new IllegalArgumentException("학원 없음"));
+
+        StudentEntity student = StudentEntity.builder()
+                .studentName(request.getStudentName())
+                .build();
+
+        studentRepository.save(student);
+
+        AcademyStudentEntity academyStudent = AcademyStudentEntity.builder()
+                .academy(academy)
+                .student(student)
+                .build();
+
+        academyStudentRepository.save(academyStudent);
+
+        return AcademyStudentResponse.from(student);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AcademyStudentResponse> getStudents(Long academyId) {
+        return academyStudentRepository.findByAcademy_Id(academyId).stream()
+                .map(e -> AcademyStudentResponse.from(e.getStudent()))
+                .toList();
+    }
+
+    public void deleteStudent(Long academyId, Long studentId) {
+
+        AcademyStudentEntity relation = academyStudentRepository
+                .findByAcademy_IdAndStudent_StudentId(academyId, studentId)
+                .orElseThrow(() -> new IllegalArgumentException("관계 없음"));
+
+        academyStudentRepository.delete(relation);
+    }
+}

--- a/src/main/java/com/example/qoocca_be/global/security/AcademyApprovalFilter.java
+++ b/src/main/java/com/example/qoocca_be/global/security/AcademyApprovalFilter.java
@@ -1,0 +1,89 @@
+package com.example.qoocca_be.global.security;
+
+import com.example.qoocca_be.academy.entity.AcademyEntity;
+import com.example.qoocca_be.academy.entity.ApprovalStatus;
+import com.example.qoocca_be.academy.repository.AcademyRepository;
+import com.example.qoocca_be.global.exception.ErrorCode;
+import com.example.qoocca_be.global.exception.ErrorResponse;
+import com.example.qoocca_be.user.security.CustomUserDetails;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class AcademyApprovalFilter extends OncePerRequestFilter {
+    private final AcademyRepository academyRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String path = request.getRequestURI();
+
+        /*if (path.startsWith("/api/auth") ||
+                path.startsWith("/api/dashboard") ||
+                path.startsWith("/api/academy/register") ||
+                (path.startsWith("/api/academy/") && !path.contains("/class") && request.getMethod().equals("GET"))) {
+            filterChain.doFilter(request, response);
+            return;
+        }*/
+        if (path.startsWith("/api/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.isAuthenticated()) {
+
+            if (authentication.getAuthorities().stream()
+                    .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            Long userId = userDetails.getUserId();
+
+            Optional<AcademyEntity> academyOpt = academyRepository.findByUserId(userId);
+
+            if (academyOpt.isPresent()) {
+                AcademyEntity academy = academyOpt.get();
+                if (academy.getApprovalStatus() != ApprovalStatus.APPROVED) {
+                    sendErrorResponse(response, ErrorCode.ACADEMY_NOT_APPROVED);
+                    return;
+                }
+            } else {
+                sendErrorResponse(response, ErrorCode.ACADEMY_NOT_FOUND);
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse res, ErrorCode errorCode) throws IOException {
+        res.setStatus(errorCode.getStatus());
+        res.setContentType("application/json;charset=UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(errorCode.getStatus())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
+
+        res.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}


### PR DESCRIPTION
 학부모 앱(Android) 과 Spring Boot 서버를
Firebase Cloud Messaging(FCM) 으로 연결하여,

수납(Receipt) 생성 / 결제 / 취소 시 학부모에게 푸시 알림을 전송하는 구조를 추가하고
Receipt 관련 API를 실제 결제/알림 흐름에 맞게 정리·보강한 작업입니다.

전체 구조 요약
[Android ParentApp]
  - FCM 토큰 발급
  - 서버에 토큰 등록
  - 푸시 수신 및 알림 표시
        ▲
        │
        │ (FCM Token 기준 메시지 라우팅)
        │
[Firebase Cloud Messaging]
        ▲
        │
        │ (Firebase Admin SDK)
        │
[Spring Boot 서버]
  - FCM 토큰 저장
  - Receipt 생성/상태 변경
  - 푸시 발송 트리거

Firebase / Android / Server 역할 분리
1️⃣ Android (ParentApp)

“알림을 받는 실제 사용자 단말”

Firebase SDK를 통해 FCM 토큰 발급

앱 시작 / 로그인 시 서버에 토큰 등록

Firebase → 기기로 전달된 푸시 수신

수납 알림 수신 후 사용자 인터랙션(결제/취소)

왜 필요한가?

서버는 휴대폰에 직접 접근 불가

FCM 토큰이 있어야 “이 학부모의 이 기기”로 알림 가능

2️⃣ Firebase Cloud Messaging (FCM)

“서버 ↔ 모바일 기기 사이의 공식 푸시 중계 서버”

각 앱/기기별 고유한 FCM 토큰 발급

서버가 보낸 메시지를 해당 토큰을 가진 기기로 전달

오프라인/백그라운드 상태에서도 안정적 전달

핵심 역할

서버는 토큰만 알고

실제 전달은 Firebase가 담당

3️⃣ Spring Boot 서버

“비즈니스 로직 + 알림 발송의 중심”

학부모(parentId) 기준 FCM 토큰 저장

수납(Receipt) 생성/결제/취소 처리

이벤트 발생 시 Firebase Admin SDK로 푸시 발송

주요 변경 사항
🔹 1. Firebase Admin SDK 초기화

서버 시작 시 service-account.json을 classpath에서 로드하여
Firebase Admin SDK 초기화

서버 → Firebase 인증을 위한 필수 설정

코드

qoocca-api/src/main/java/com/qoocca/teachers/api/global/config/FirebaseConfig.java

의존성 추가:

qoocca-api/build.gradle

qoocca-db/build.gradle

🔹 2. FCM 토큰 저장 구조

학부모(parent) 기준으로 FCM 토큰 관리

한 학부모가 여러 기기를 사용할 수 있는 구조 확장 가능

구성

Entity

FirebaseTokenEntity

parentId (user_id 컬럼) + fcmToken

Repository

findByParentId(...)

코드

qoocca-db/src/main/java/com/qoocca/teachers/db/fcm/FirebaseTokenEntity.java

qoocca-db/src/main/java/com/qoocca/teachers/db/fcm/FirebaseTokenRepository.java

🔹 3. FCM 토큰 등록 API

Android 앱에서 발급된 토큰을 서버에 등록

기존 토큰이 있으면 업데이트, 없으면 신규 생성

API

POST /api/fcm/register?parentId=...&fcmToken=...


코드

Controller

FcmController.java

Service

FcmPushService.java

🔹 4. Android ↔ Server 연동 흐름

Android 앱 실행 / 로그인

Firebase SDK가 FCM 토큰 발급

앱에서 /api/fcm/register 호출

서버는 parentId 기준으로 토큰 저장

이후 Receipt 이벤트 발생 시 해당 토큰으로 푸시 발송

🔹 5. 푸시 발송 트리거 (Receipt 연동)

수납 생성 시

학생과 연결된 모든 학부모(parent)에게 푸시 발송

향후 결제/취소/미납 알림 확장 가능

발송 데이터

receiptId

title

body
(※ data payload 기반)

코드

ReceiptService.java

FcmPushService.java

🔹 6. Receipt 관련 API 정리
학생 수납 관리
POST /api/student/{studentId}/receipt
GET  /api/student/{studentId}/receipt
GET  /api/student/{studentId}/receipt/month
PUT  /api/student/{studentId}/receipt/{receiptId}


카드 등록 여부 체크

월 중복 수납 발급 방지

수납 생성 시 FCM 푸시 발송

코드

ReceiptController.java

ReceiptService.java

학부모 결제/취소
POST /api/receipt/{receiptId}/pay?parentId=...
POST /api/receipt/{receiptId}/cancel?parentId=...


코드

ReceiptPaymentController.java

왜 서버에 FCM 토큰을 저장하는가?

서버는 “이벤트 발생”만 인지

누구에게 보낼지 판단하려면 parentId → FCM 토큰 매핑 필요

수납/결제/취소 같은 도메인 이벤트와 푸시 알림을 자연스럽게 연결

보안 설정

현재 단계에서는 테스트 및 연동 확인을 위해:

FCM 토큰 등록 API

Receipt 관련 API

permitAll 설정

코드

qoocca-auth/src/main/java/com/qoocca/teachers/auth/config/SecurityConfig.java

(향후 JWT 인증 후 parentId 자동 매핑 예정)

요약

✔ Android–Firebase–Server 간 푸시 알림 파이프라인 구축

✔ 학부모 기준 FCM 토큰 관리

✔ Receipt 도메인 이벤트와 푸시 알림 연동

✔ 실제 서비스 확장 가능한 구조로 설계

추가 : gititnore 에 추가한 여러 파일이 있습니다 개인적으로 전달하겠습니다!