### PR TITLE
fix/17 출결 일자 기준 매칭 및 결석/퇴실 처리 보강

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,4 @@ key.properties
 *.log
 *.yml
 *.yaml
-!qoocca-api/src/main/resources/application.yml
-!qoocca-api/src/main/resources/application-local.yml
-!qoocca-api/src/main/resources/application-prod.yml
 !nginx/nginx.conf

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/attendance/service/AttendanceService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/attendance/service/AttendanceService.java
@@ -41,7 +41,7 @@ public class AttendanceService {
         StudentEntity student = studentRepository.findById(studentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.STUDENT_NOT_FOUND));
 
-        ClassInfoEntity targetClass = findMatchingClass(studentId, request.getCheckIn());
+        ClassInfoEntity targetClass = findMatchingClass(studentId, request.getAttendanceDate(), request.getCheckIn());
 
         // 중복 등원 체크
         if (attendanceRepository.existsByStudent_StudentIdAndClassInfo_ClassIdAndAttendanceDate(
@@ -62,10 +62,10 @@ public class AttendanceService {
         return AttendanceResponse.fromEntity(saved);
     }
 
-    private ClassInfoEntity findMatchingClass(Long studentId, LocalTime checkIn) {
+    private ClassInfoEntity findMatchingClass(Long studentId, LocalDate attendanceDate, LocalTime checkIn) {
         List<ClassInfoEntity> classes = classInfoStudentRepository.findClassesByStudentId(studentId, StudentStatus.ENROLLED);
 
-        String dayOfWeek = LocalDate.now().getDayOfWeek().name().toLowerCase();
+        String dayOfWeek = attendanceDate.getDayOfWeek().name().toLowerCase();
 
         return classes.stream()
                 .filter(c -> isClassOnDay(c, dayOfWeek))
@@ -77,7 +77,8 @@ public class AttendanceService {
     @Transactional
     public AttendanceResponse updateCheckOut(Long studentId, LocalDate date) {
         AttendanceEntity attendance = attendanceRepository
-                .findByStudent_StudentIdAndAttendanceDate(studentId, date)
+                .findFirstByStudent_StudentIdAndAttendanceDateAndCheckOutIsNullOrderByCheckInDesc(studentId, date)
+                .or(() -> attendanceRepository.findByStudent_StudentIdAndAttendanceDate(studentId, date))
                 .orElseThrow(() -> new CustomException(ErrorCode.ATTENDANCE_NOT_FOUND));
 
         attendance.processCheckOut(attendance.getClassInfo().getEndTime());

--- a/qoocca-api/src/test/java/com/qoocca/teachers/api/attendance/service/AttendanceServiceTest.java
+++ b/qoocca-api/src/test/java/com/qoocca/teachers/api/attendance/service/AttendanceServiceTest.java
@@ -1,0 +1,149 @@
+package com.qoocca.teachers.api.attendance.service;
+
+import com.qoocca.teachers.api.attendance.model.AttendanceCreateRequest;
+import com.qoocca.teachers.common.global.exception.CustomException;
+import com.qoocca.teachers.common.global.exception.ErrorCode;
+import com.qoocca.teachers.db.attendance.entity.AttendanceEntity;
+import com.qoocca.teachers.db.attendance.repository.AttendanceRepository;
+import com.qoocca.teachers.db.classInfo.entity.ClassInfoEntity;
+import com.qoocca.teachers.db.classInfo.entity.StudentStatus;
+import com.qoocca.teachers.db.classInfo.repository.ClassInfoRepository;
+import com.qoocca.teachers.db.classInfo.repository.ClassInfoStudentRepository;
+import com.qoocca.teachers.db.student.entity.StudentEntity;
+import com.qoocca.teachers.db.student.repository.StudentRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AttendanceServiceTest {
+
+    @Mock
+    private AttendanceRepository attendanceRepository;
+    @Mock
+    private StudentRepository studentRepository;
+    @Mock
+    private ClassInfoStudentRepository classInfoStudentRepository;
+    @Mock
+    private ClassInfoRepository classInfoRepository;
+
+    @InjectMocks
+    private AttendanceService attendanceService;
+
+    @Test
+    void createAttendanceUsesRequestAttendanceDateForDayMatching() {
+        Long studentId = 1L;
+        LocalDate attendanceDate = LocalDate.of(2026, 2, 3); // Tuesday
+        LocalTime checkIn = LocalTime.of(10, 0);
+
+        StudentEntity student = buildStudent(studentId, "학생A");
+        ClassInfoEntity mondayClass = buildClass(10L, "월요반", true, false, LocalTime.of(9, 0), LocalTime.of(12, 0));
+        ClassInfoEntity tuesdayClass = buildClass(20L, "화요반", false, true, LocalTime.of(9, 0), LocalTime.of(12, 0));
+
+        AttendanceCreateRequest request = AttendanceCreateRequest.builder()
+                .attendanceDate(attendanceDate)
+                .checkIn(checkIn)
+                .status(AttendanceEntity.AttendanceStatus.PRESENT)
+                .build();
+
+        when(studentRepository.findById(studentId)).thenReturn(Optional.of(student));
+        when(classInfoStudentRepository.findClassesByStudentId(studentId, StudentStatus.ENROLLED))
+                .thenReturn(List.of(mondayClass, tuesdayClass));
+        when(attendanceRepository.existsByStudent_StudentIdAndClassInfo_ClassIdAndAttendanceDate(studentId, 20L, attendanceDate))
+                .thenReturn(false);
+        when(attendanceRepository.save(any(AttendanceEntity.class))).thenAnswer(invocation -> {
+            AttendanceEntity source = invocation.getArgument(0);
+            return AttendanceEntity.builder()
+                    .attendanceId(100L)
+                    .student(source.getStudent())
+                    .classInfo(source.getClassInfo())
+                    .attendanceDate(source.getAttendanceDate())
+                    .checkIn(source.getCheckIn())
+                    .checkOut(source.getCheckOut())
+                    .status(source.getStatus())
+                    .build();
+        });
+
+        var response = attendanceService.createAttendance(studentId, request);
+
+        verify(attendanceRepository).existsByStudent_StudentIdAndClassInfo_ClassIdAndAttendanceDate(studentId, 20L, attendanceDate);
+        assertEquals(20L, response.getClassId());
+        assertEquals(attendanceDate, response.getAttendanceDate());
+    }
+
+    @Test
+    void updateCheckOutPrefersOpenAttendanceRecord() {
+        Long studentId = 1L;
+        LocalDate attendanceDate = LocalDate.of(2026, 2, 3);
+        StudentEntity student = buildStudent(studentId, "학생A");
+        ClassInfoEntity classInfo = buildClass(20L, "화요반", false, true, LocalTime.of(9, 0), LocalTime.of(18, 0));
+
+        AttendanceEntity openAttendance = AttendanceEntity.builder()
+                .attendanceId(111L)
+                .student(student)
+                .classInfo(classInfo)
+                .attendanceDate(attendanceDate)
+                .checkIn(LocalTime.of(10, 0))
+                .status(AttendanceEntity.AttendanceStatus.PRESENT)
+                .build();
+
+        when(attendanceRepository.findFirstByStudent_StudentIdAndAttendanceDateAndCheckOutIsNullOrderByCheckInDesc(studentId, attendanceDate))
+                .thenReturn(Optional.of(openAttendance));
+
+        var response = attendanceService.updateCheckOut(studentId, attendanceDate);
+
+        verify(attendanceRepository, never()).findByStudent_StudentIdAndAttendanceDate(studentId, attendanceDate);
+        assertEquals(111L, response.getAttendanceId());
+        assertNotNull(response.getCheckOut());
+    }
+
+    @Test
+    void updateCheckOutThrowsWhenNoAttendanceRecordExists() {
+        Long studentId = 1L;
+        LocalDate attendanceDate = LocalDate.of(2026, 2, 3);
+
+        when(attendanceRepository.findFirstByStudent_StudentIdAndAttendanceDateAndCheckOutIsNullOrderByCheckInDesc(studentId, attendanceDate))
+                .thenReturn(Optional.empty());
+        when(attendanceRepository.findByStudent_StudentIdAndAttendanceDate(studentId, attendanceDate))
+                .thenReturn(Optional.empty());
+
+        CustomException exception = assertThrows(CustomException.class,
+                () -> attendanceService.updateCheckOut(studentId, attendanceDate));
+
+        assertEquals(ErrorCode.ATTENDANCE_NOT_FOUND, exception.getErrorCode());
+    }
+
+    private StudentEntity buildStudent(Long studentId, String studentName) {
+        return StudentEntity.builder()
+                .studentId(studentId)
+                .studentName(studentName)
+                .build();
+    }
+
+    private ClassInfoEntity buildClass(Long classId, String className, boolean monday, boolean tuesday,
+                                       LocalTime startTime, LocalTime endTime) {
+        return ClassInfoEntity.builder()
+                .classId(classId)
+                .className(className)
+                .startTime(startTime)
+                .endTime(endTime)
+                .monday(monday)
+                .tuesday(tuesday)
+                .build();
+    }
+}

--- a/qoocca-db/src/main/java/com/qoocca/teachers/db/attendance/repository/AttendanceRepository.java
+++ b/qoocca-db/src/main/java/com/qoocca/teachers/db/attendance/repository/AttendanceRepository.java
@@ -28,6 +28,11 @@ public interface AttendanceRepository
             LocalDate attendanceDate
     );
 
+    Optional<AttendanceEntity> findFirstByStudent_StudentIdAndAttendanceDateAndCheckOutIsNullOrderByCheckInDesc(
+            Long studentId,
+            LocalDate attendanceDate
+    );
+
     // 특정 학원에서 특정 학생의 일정 기간(예: 이번 달) 출결 데이터를 조회
     @Query("""
     SELECT a FROM AttendanceEntity a
@@ -78,6 +83,15 @@ public interface AttendanceRepository
     SELECT cs.student, cs.classInfo, :today, 'ABSENT', NOW(), NOW()
     FROM ClassInfoStudentEntity cs
     WHERE cs.status = 'ENROLLED'
+      AND (
+          (function('DAYOFWEEK', :today) = 1 AND cs.classInfo.sunday = true) OR
+          (function('DAYOFWEEK', :today) = 2 AND cs.classInfo.monday = true) OR
+          (function('DAYOFWEEK', :today) = 3 AND cs.classInfo.tuesday = true) OR
+          (function('DAYOFWEEK', :today) = 4 AND cs.classInfo.wednesday = true) OR
+          (function('DAYOFWEEK', :today) = 5 AND cs.classInfo.thursday = true) OR
+          (function('DAYOFWEEK', :today) = 6 AND cs.classInfo.friday = true) OR
+          (function('DAYOFWEEK', :today) = 7 AND cs.classInfo.saturday = true)
+      )
       AND NOT EXISTS (
           SELECT 1 FROM AttendanceEntity a
           WHERE a.student = cs.student


### PR DESCRIPTION
 - 출결 로직의 날짜 기준 일관성을 맞추고, 퇴실/자동결석 처리 정확도를 개선했습니다.
  - 주요 변경사항
      - AttendanceService#createAttendance
          - 수업 매칭 기준을 LocalDate.now()에서 요청값 attendanceDate로 변경
      - AttendanceService#updateCheckOut
          - 당일 미퇴실(open) 출결을 우선 조회 후 퇴실 처리
          - 없을 경우 기존 일자 조회로 fallback
      - AttendanceRepository
          - 미퇴실 출결 조회 메서드 추가
            findFirstByStudent_StudentIdAndAttendanceDateAndCheckOutIsNullOrderByCheckInDesc
          - 자동 결석 insert 쿼리에 요일 조건(일~토) 추가
      - 테스트 추가
          - AttendanceServiceTest
              - 요청 attendanceDate 기준 요일 매칭
              - 퇴실 처리 시 open 출결 우선 처리
              - 출결 미존재 시 예외 반환