### PR TITLE
refactor/3 classInfo 수정

### DIFF
--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/AcademyStudentUploadService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/academy/service/AcademyStudentUploadService.java
@@ -144,6 +144,7 @@ public class AcademyStudentUploadService {
                     }
 
                     classInfoStudentService.register(
+                            academyId,
                             targetClassId,
                             new ClassStudentRequest(student.getStudentId())
                     );

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/attendance/service/AttendanceAnalyticsService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/attendance/service/AttendanceAnalyticsService.java
@@ -64,7 +64,7 @@ public class AttendanceAnalyticsService {
     }
 
     public List<ClassSummaryResponse> getClassSummariesByDate(Long academyId, LocalDate targetDate) {
-        String dayOfWeek = targetDate.getDayOfWeek().name();
+        String dayOfWeek = targetDate.getDayOfWeek().name().toLowerCase();
 
         List<ClassInfoEntity> classes = classInfoRepository.findAllByAcademyIdAndDayOfWeek(academyId, dayOfWeek);
         List<AttendanceEntity> allAttendances = attendanceRepository.findByAttendanceDateWithDetails(targetDate);
@@ -102,7 +102,8 @@ public class AttendanceAnalyticsService {
         LocalDate startDate = yearMonth.atDay(1);
         LocalDate endDate = yearMonth.atEndOfMonth();
 
-        List<ClassInfoStudentEntity> enrollments = classInfoStudentRepository.findByClassInfo_ClassId(classId);
+        List<ClassInfoStudentEntity> enrollments =
+                classInfoStudentRepository.findAllByClassInfo_ClassIdAndStatus(classId, StudentStatus.ENROLLED);
 
         return enrollments.stream().map(enroll -> {
             StudentEntity student = enroll.getStudent();

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/attendance/service/AttendanceCommandService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/attendance/service/AttendanceCommandService.java
@@ -58,6 +58,10 @@ public class AttendanceCommandService {
                 .or(() -> attendanceRepository.findByStudent_StudentIdAndAttendanceDate(studentId, request.getAttendanceDate()))
                 .orElseThrow(() -> new CustomException(ErrorCode.ATTENDANCE_NOT_FOUND));
 
+        if (attendance.getCheckIn() == null || request.getCheckOut().isBefore(attendance.getCheckIn())) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
         attendance.setCheckOut(request.getCheckOut());
         if (request.getCheckOut().isBefore(attendance.getClassInfo().getEndTime())) {
             attendance.setStatus(AttendanceEntity.AttendanceStatus.EARLY_LEAVE);

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/attendance/service/AttendanceQueryService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/attendance/service/AttendanceQueryService.java
@@ -30,7 +30,7 @@ public class AttendanceQueryService {
 
     public AttendanceResponse getAttendanceByDate(Long studentId, LocalDate date) {
         AttendanceEntity attendance = attendanceRepository
-                .findByStudent_StudentIdAndAttendanceDate(studentId, date)
+                .findFirstByStudent_StudentIdAndAttendanceDateOrderByCheckInDesc(studentId, date)
                 .orElseThrow(() -> new CustomException(ErrorCode.ATTENDANCE_NOT_FOUND));
 
         return AttendanceResponse.fromEntity(attendance);

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/controller/ClassInfoController.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/controller/ClassInfoController.java
@@ -9,13 +9,14 @@ import com.qoocca.teachers.api.classInfo.service.ClassInfoStudentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "Class Info API", description = "학원 반 관리 API")
+@Tag(name = "Class Info API", description = "학원별 클래스 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/academy/{academyId}/class")
@@ -28,7 +29,7 @@ public class ClassInfoController {
     @PostMapping
     public ResponseEntity<ClassCreateResponse> createClass(
             @Parameter(description = "학원 ID") @PathVariable Long academyId,
-            @RequestBody ClassCreateRequest request
+            @Valid @RequestBody ClassCreateRequest request
     ) {
         return ResponseEntity.ok(classInfoService.createClass(academyId, request));
     }
@@ -41,15 +42,15 @@ public class ClassInfoController {
         return ResponseEntity.ok(classInfoService.getClasses(academyId));
     }
 
-    @Operation(summary = "학생 반 이동", description = "학생을 다른 반으로 이동시킵니다.")
+    @Operation(summary = "학생 반 이동", description = "학생을 같은 학원 내 다른 반으로 이동시킵니다.")
     @PutMapping("/{classId}/student/{studentId}/move")
     public ResponseEntity<Void> moveStudent(
             @Parameter(description = "학원 ID") @PathVariable Long academyId,
             @Parameter(description = "현재 반 ID") @PathVariable Long classId,
             @Parameter(description = "학생 ID") @PathVariable Long studentId,
-            @RequestBody ClassStudentMoveRequest request
+            @Valid @RequestBody ClassStudentMoveRequest request
     ) {
-        classInfoStudentService.moveStudent(classId, studentId, request.getTargetClassId());
+        classInfoStudentService.moveStudent(academyId, classId, studentId, request.getTargetClassId());
         return ResponseEntity.ok().build();
     }
 }

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/controller/ClassInfoStudentController.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/controller/ClassInfoStudentController.java
@@ -1,63 +1,67 @@
 package com.qoocca.teachers.api.classInfo.controller;
 
+import com.qoocca.teachers.api.classInfo.model.request.ClassStudentModifyRequest;
 import com.qoocca.teachers.api.classInfo.model.request.ClassStudentRequest;
 import com.qoocca.teachers.api.classInfo.model.response.ClassStudentResponse;
 import com.qoocca.teachers.api.classInfo.service.ClassInfoStudentService;
-import com.qoocca.teachers.api.classInfo.model.request.ClassStudentModifyRequest;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "Class Student API", description = "클래스 수강생 관리 API (배정, 상태 변경, 조회, 삭제)")
+@Tag(name = "Class Student API", description = "클래스 수강생 관리 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/class/{classId}/student")
+@RequestMapping("/api/academy/{academyId}/class/{classId}/student")
 public class ClassInfoStudentController {
 
     private final ClassInfoStudentService service;
 
-    @Operation(summary = "클래스에 학생 등록", description = "기존에 등록된 학생을 특정 클래스의 수강생으로 배정합니다.")
+    @Operation(summary = "학생 등록", description = "기존 학생을 클래스 수강생으로 등록합니다.")
     @PostMapping
     public ResponseEntity<Void> register(
+            @Parameter(description = "학원 ID", example = "1") @PathVariable Long academyId,
             @Parameter(description = "클래스 ID", example = "1") @PathVariable Long classId,
-            @RequestBody ClassStudentRequest request
+            @Valid @RequestBody ClassStudentRequest request
     ) {
-        service.register(classId, request);
+        service.register(academyId, classId, request);
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "학생 수강 상태 수정", description = "특정 클래스를 수강 중인 학생의 상태(재원, 퇴원, 휴원 등)를 변경합니다.")
+    @Operation(summary = "수강 상태 수정", description = "클래스 내 학생 수강 상태를 수정합니다.")
     @PutMapping("/{studentId}")
     public ResponseEntity<Void> modifyStatus(
+            @Parameter(description = "학원 ID", example = "1") @PathVariable Long academyId,
             @Parameter(description = "클래스 ID", example = "1") @PathVariable Long classId,
             @Parameter(description = "학생 ID", example = "10") @PathVariable Long studentId,
-            @RequestBody ClassStudentModifyRequest request
+            @Valid @RequestBody ClassStudentModifyRequest request
     ) {
-        service.modifyStatus(classId, studentId, request);
+        service.modifyStatus(academyId, classId, studentId, request);
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "클래스별 수강생 목록 조회", description = "해당 클래스에 배정된 모든 학생의 목록을 조회합니다.")
+    @Operation(summary = "수강생 목록 조회", description = "클래스에 등록된 수강생 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<List<ClassStudentResponse>> getStudents(
+            @Parameter(description = "학원 ID", example = "1") @PathVariable Long academyId,
             @Parameter(description = "클래스 ID", example = "1") @PathVariable Long classId
     ) {
-        return ResponseEntity.ok(service.getStudents(classId));
+        return ResponseEntity.ok(service.getStudents(academyId, classId));
     }
 
-    @Operation(summary = "클래스에서 학생 제외", description = "해당 클래스의 수강 명단에서 학생을 삭제합니다.")
+    @Operation(summary = "학생 제외", description = "클래스 수강 명단에서 학생을 제외합니다.")
     @DeleteMapping("/{studentId}")
     public ResponseEntity<Void> remove(
+            @Parameter(description = "학원 ID", example = "1") @PathVariable Long academyId,
             @Parameter(description = "클래스 ID", example = "1") @PathVariable Long classId,
             @Parameter(description = "학생 ID", example = "10") @PathVariable Long studentId
     ) {
-        service.remove(classId, studentId);
+        service.remove(academyId, classId, studentId);
         return ResponseEntity.ok().build();
     }
 }

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/model/request/ClassCreateRequest.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/model/request/ClassCreateRequest.java
@@ -2,6 +2,10 @@ package com.qoocca.teachers.api.classInfo.model.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Data;
 
 import java.time.LocalTime;
@@ -9,22 +13,17 @@ import java.time.LocalTime;
 @Data
 public class ClassCreateRequest {
 
-    @Schema(description = "수업명", example = "Alpha 교과국어 초등반")
+    @NotBlank
+    @Schema(description = "반 이름", example = "알파 교과국어 초등반")
     private String className;
 
-    @Schema(
-            description = "수업 시작 시간 (HH:mm)",
-            example = "14:00",
-            type = "string"
-    )
+    @NotNull
+    @Schema(description = "수업 시작 시간 (HH:mm)", example = "14:00", type = "string")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     private LocalTime startTime;
 
-    @Schema(
-            description = "수업 종료 시간 (HH:mm)",
-            example = "16:00",
-            type = "string"
-    )
+    @NotNull
+    @Schema(description = "수업 종료 시간 (HH:mm)", example = "16:00", type = "string")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
     private LocalTime endTime;
 
@@ -49,12 +48,20 @@ public class ClassCreateRequest {
     @Schema(description = "일요일 수업 여부", example = "false")
     private boolean sunday;
 
-    @Schema(description = "수업 가격 (원)", example = "600000")
+    @PositiveOrZero
+    @Schema(description = "수업 금액", example = "600000")
     private Long price;
 
-    @Schema(description = "연령 ID (age 테이블 PK)", example = "2")
+    @NotNull
+    @Schema(description = "연령 ID", example = "2")
     private Long ageId;
 
-    @Schema(description = "과목 ID (subject 테이블 PK)", example = "70")
+    @NotNull
+    @Schema(description = "과목 ID", example = "70")
     private Long subjectId;
+
+    @AssertTrue(message = "최소 1개 이상의 수업 요일을 선택해야 합니다.")
+    public boolean isAnyClassDaySelected() {
+        return monday || tuesday || wednesday || thursday || friday || saturday || sunday;
+    }
 }

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/model/request/ClassStudentRequest.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/model/request/ClassStudentRequest.java
@@ -1,6 +1,7 @@
 package com.qoocca.teachers.api.classInfo.model.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ClassStudentRequest {
 
+    @NotNull
     @Schema(description = "등록할 기존 학생 ID", example = "1")
     private Long studentId;
 }

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/service/ClassInfoService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/service/ClassInfoService.java
@@ -68,7 +68,7 @@ public class ClassInfoService {
     @Transactional(readOnly = true)
     public List<ClassGetResponse> getClasses(Long academyId) {
 
-        return classInfoRepository.findByAcademy_Id(academyId).stream()
+        return classInfoRepository.findByAcademy_IdWithDetails(academyId).stream()
                 .map(ClassGetResponse::fromEntity)
                 .toList();
     }

--- a/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/service/ClassInfoStudentService.java
+++ b/qoocca-api/src/main/java/com/qoocca/teachers/api/classInfo/service/ClassInfoStudentService.java
@@ -1,22 +1,20 @@
 package com.qoocca.teachers.api.classInfo.service;
 
+import com.qoocca.teachers.api.classInfo.model.request.ClassStudentModifyRequest;
+import com.qoocca.teachers.api.classInfo.model.request.ClassStudentRequest;
+import com.qoocca.teachers.api.classInfo.model.response.ClassStudentResponse;
+import com.qoocca.teachers.common.global.exception.CustomException;
+import com.qoocca.teachers.common.global.exception.ErrorCode;
 import com.qoocca.teachers.db.classInfo.entity.ClassInfoEntity;
 import com.qoocca.teachers.db.classInfo.entity.ClassInfoStudentEntity;
 import com.qoocca.teachers.db.classInfo.entity.StudentStatus;
-import com.qoocca.teachers.api.classInfo.model.request.ClassStudentRequest;
-import com.qoocca.teachers.api.classInfo.model.response.ClassStudentResponse;
-import com.qoocca.teachers.api.classInfo.model.request.ClassStudentModifyRequest;
-
 import com.qoocca.teachers.db.classInfo.repository.ClassInfoRepository;
 import com.qoocca.teachers.db.classInfo.repository.ClassInfoStudentRepository;
-import com.qoocca.teachers.common.global.exception.CustomException;
-import com.qoocca.teachers.common.global.exception.ErrorCode;
 import com.qoocca.teachers.db.student.entity.StudentEntity;
 import com.qoocca.teachers.db.student.repository.StudentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 
 import java.util.List;
 
@@ -27,74 +25,53 @@ public class ClassInfoStudentService {
 
     private final ClassInfoRepository classInfoRepository;
     private final StudentRepository studentRepository;
-    private final ClassInfoStudentRepository repository;
     private final ClassInfoStudentRepository classInfoStudentRepository;
-    /**
-     * 기존 학생을 클래스에 배정
-     */
-    public void register(Long classId, ClassStudentRequest request) {
 
-        // 이미 등록되어 있는지 체크
-        if (repository.existsByClassInfo_ClassIdAndStudent_StudentId(classId, request.getStudentId())) {
+    public void register(Long academyId, Long classId, ClassStudentRequest request) {
+        ClassInfoEntity classInfo = getClassInAcademy(academyId, classId);
+
+        if (classInfoStudentRepository.existsByClassInfo_ClassIdAndStudent_StudentId(classId, request.getStudentId())) {
             throw new CustomException(ErrorCode.STUDENT_ALREADY_ENROLLED);
         }
 
-        // 클래스 존재 확인
-        ClassInfoEntity classInfo = classInfoRepository.findById(classId)
-                .orElseThrow(() -> new CustomException(ErrorCode.CLASS_NOT_FOUND));
-
-        // 학생 존재 확인
         StudentEntity student = studentRepository.findById(request.getStudentId())
                 .orElseThrow(() -> new CustomException(ErrorCode.STUDENT_NOT_FOUND));
 
-        // 기존 학생이므로 신규 생성 X, 바로 클래스-학생 매핑 테이블에 등록
         ClassInfoStudentEntity entity = ClassInfoStudentEntity.builder()
                 .classInfo(classInfo)
                 .student(student)
                 .build();
 
-        repository.save(entity);
+        classInfoStudentRepository.save(entity);
     }
 
-    public void modifyStatus(
-            Long classId,
-            Long studentId,
-            ClassStudentModifyRequest request
-    ) {
-        ClassInfoStudentEntity entity = repository
+    public void modifyStatus(Long academyId, Long classId, Long studentId, ClassStudentModifyRequest request) {
+        getClassInAcademy(academyId, classId);
+
+        ClassInfoStudentEntity entity = classInfoStudentRepository
                 .findByClassInfo_ClassIdAndStudent_StudentId(classId, studentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ENROLLMENT_NOT_FOUND));
 
         entity.setStatus(request.getStatus());
-        // JPA Dirty Checking으로 자동 update
     }
 
-    @Transactional
-    public void moveStudent(Long classId, Long studentId, Long targetClassId) {
+    public void moveStudent(Long academyId, Long classId, Long studentId, Long targetClassId) {
+        getClassInAcademy(academyId, classId);
+        ClassInfoEntity targetClass = getClassInAcademy(academyId, targetClassId);
 
-        // 기존 반 수강 정보 조회
         ClassInfoStudentEntity current = classInfoStudentRepository
                 .findByClassInfo_ClassIdAndStudent_StudentId(classId, studentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ENROLLMENT_NOT_FOUND));
 
-        // 이동할 반 존재 확인
-        ClassInfoEntity targetClass = classInfoRepository.findById(targetClassId)
-                .orElseThrow(() -> new CustomException(ErrorCode.CLASS_NOT_FOUND));
-
-        // 중복 등록 방지
         if (classInfoStudentRepository.existsByClassInfo_ClassIdAndStudent_StudentId(targetClassId, studentId)) {
             throw new CustomException(ErrorCode.STUDENT_ALREADY_ENROLLED);
         }
 
-        StudentEntity student = current.getStudent();
-
-        // 기존 관계 삭제
         classInfoStudentRepository.delete(current);
 
-        // 새 관계 생성
         ClassInfoStudentEntity newEntity = ClassInfoStudentEntity.builder()
                 .classInfo(targetClass)
-                .student(student)
+                .student(current.getStudent())
                 .status(StudentStatus.ENROLLED)
                 .build();
 
@@ -102,18 +79,31 @@ public class ClassInfoStudentService {
     }
 
     @Transactional(readOnly = true)
-    public List<ClassStudentResponse> getStudents(Long classId) {
-        return repository.findByClassInfo_ClassId(classId)
-                .stream()
+    public List<ClassStudentResponse> getStudents(Long academyId, Long classId) {
+        getClassInAcademy(academyId, classId);
+
+        return classInfoStudentRepository.findByClassInfo_ClassId(classId).stream()
                 .map(ClassStudentResponse::from)
                 .toList();
     }
 
-    public void remove(Long classId, Long studentId) {
-        ClassInfoStudentEntity entity = repository
+    public void remove(Long academyId, Long classId, Long studentId) {
+        getClassInAcademy(academyId, classId);
+
+        ClassInfoStudentEntity entity = classInfoStudentRepository
                 .findByClassInfo_ClassIdAndStudent_StudentId(classId, studentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ENROLLMENT_NOT_FOUND));
 
-        repository.delete(entity);
+        classInfoStudentRepository.delete(entity);
+    }
+
+    private ClassInfoEntity getClassInAcademy(Long academyId, Long classId) {
+        ClassInfoEntity classInfo = classInfoRepository.findById(classId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLASS_NOT_FOUND));
+
+        if (!classInfo.getAcademy().getId().equals(academyId)) {
+            throw new CustomException(ErrorCode.NO_AUTHORITY);
+        }
+        return classInfo;
     }
 }

--- a/qoocca-api/src/test/java/com/qoocca/teachers/api/attendance/service/AttendanceServiceTest.java
+++ b/qoocca-api/src/test/java/com/qoocca/teachers/api/attendance/service/AttendanceServiceTest.java
@@ -133,6 +133,41 @@ class AttendanceServiceTest {
         assertEquals(ErrorCode.ATTENDANCE_NOT_FOUND, exception.getErrorCode());
     }
 
+    @Test
+    void updateCheckOutThrowsWhenCheckOutIsBeforeCheckIn() {
+        Long studentId = 1L;
+        LocalDate attendanceDate = LocalDate.of(2026, 2, 3);
+
+        StudentEntity student = buildStudent(studentId, "?숈깮A");
+        ClassInfoEntity classInfo =
+                buildClass(20L, "classA", false, true,
+                        LocalTime.of(9, 0), LocalTime.of(18, 0));
+
+        AttendanceEntity openAttendance = AttendanceEntity.builder()
+                .attendanceId(111L)
+                .student(student)
+                .classInfo(classInfo)
+                .attendanceDate(attendanceDate)
+                .checkIn(LocalTime.of(10, 0))
+                .status(AttendanceEntity.AttendanceStatus.PRESENT)
+                .build();
+
+        AttendanceCheckOutRequest request =
+                new AttendanceCheckOutRequest(attendanceDate, LocalTime.of(9, 30));
+
+        when(attendanceRepository
+                .findFirstByStudent_StudentIdAndAttendanceDateAndCheckOutIsNullOrderByCheckInDesc(
+                        studentId, attendanceDate))
+                .thenReturn(Optional.of(openAttendance));
+
+        CustomException exception = assertThrows(
+                CustomException.class,
+                () -> attendanceService.updateCheckOut(studentId, request)
+        );
+
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
+    }
+
     private StudentEntity buildStudent(Long studentId, String studentName) {
         return StudentEntity.builder()
                 .studentId(studentId)

--- a/qoocca-db/src/main/java/com/qoocca/teachers/db/attendance/repository/AttendanceRepository.java
+++ b/qoocca-db/src/main/java/com/qoocca/teachers/db/attendance/repository/AttendanceRepository.java
@@ -28,6 +28,11 @@ public interface AttendanceRepository
             LocalDate attendanceDate
     );
 
+    Optional<AttendanceEntity> findFirstByStudent_StudentIdAndAttendanceDateOrderByCheckInDesc(
+            Long studentId,
+            LocalDate attendanceDate
+    );
+
     Optional<AttendanceEntity> findFirstByStudent_StudentIdAndAttendanceDateAndCheckOutIsNullOrderByCheckInDesc(
             Long studentId,
             LocalDate attendanceDate


### PR DESCRIPTION
 ## 배경
  클래스 수강생 관리/출결 처리에서 학원 스코프가 명확하지 않은 부분과 입력 검증 누락이 있어,
  권한 경계와 데이터 정합성을 강화하기 위해 리팩토링했습니다.

  ## 주요 변경사항

  ### 1) 클래스 수강생 API를 학원 스코프로 통일
  - 엔드포인트 변경
    - 기존: `/api/class/{classId}/student`
    - 변경: `/api/academy/{academyId}/class/{classId}/student`
  - `ClassInfoStudentService` 전 메서드 시그니처에 `academyId` 추가
    - `register`, `modifyStatus`, `moveStudent`, `getStudents`, `remove`
  - `getClassInAcademy()` 검증 로직 추가
    - 클래스 존재 확인 + 요청 학원 소속 확인
    - 불일치 시 `NO_AUTHORITY` 예외 처리
  - 학생 반 이동도 같은 학원 내 이동으로 제한

  ### 2) 입력값 검증 강화
  - 컨트롤러에 `@Valid` 적용
  - `ClassCreateRequest` 검증 추가
    - `@NotBlank className`
    - `@NotNull startTime/endTime/ageId/subjectId`
    - `@PositiveOrZero price`
    - `@AssertTrue` (최소 1개 요일 선택)
  - `ClassStudentRequest.studentId`에 `@NotNull` 추가

  ### 3) 출결 로직 보완
  - `AttendanceQueryService`
    - 단일 날짜 조회 시 최신 체크인 기준 조회로 변경
      (`findFirstByStudent_StudentIdAndAttendanceDateOrderByCheckInDesc`)
  - `AttendanceCommandService`
    - 체크아웃 시간이 체크인 이전이면 `INVALID_INPUT_VALUE` 예외 처리
  - `AttendanceAnalyticsService`
    - 요일 비교 시 `toLowerCase()` 적용
    - 월간 통계 대상 학생을 `ENROLLED` 상태로 제한

  ### 4) 기타
  - `ClassInfoService.getClasses()` 조회를 `findByAcademy_IdWithDetails()`로 변경
  - 엑셀 업로드 경로(`AcademyStudentUploadService`)에서 수강생 등록 호출 시 `academyId` 전달

  ## 테스트
  - `AttendanceServiceTest`에 체크아웃 < 체크인 케이스 추가
    - `updateCheckOutThrowsWhenCheckOutIsBeforeCheckIn`
  - 로컬 전체 테스트 실행 여부: (작성 필요)

  ## 영향도 / 확인 필요사항
  - **API 경로 변경 영향 있음**: 프론트/외부 연동에서 수강생 API 경로 수정 필요
  - 권한 경계가 학원 단위로 강화되어, 기존에 허용되던 교차 학원 접근은 차단됨